### PR TITLE
Add path to error page in demo app

### DIFF
--- a/demo/app/controllers/examples_controller.rb
+++ b/demo/app/controllers/examples_controller.rb
@@ -19,4 +19,9 @@ class ExamplesController < ApplicationController
       ActiveModel::Name.new(self, nil, "Resource")
     end
   end
+
+  # This enpoints serves for testing behavior when error page is encountered
+  def error
+    redirect_to "/500.html"
+  end
 end

--- a/demo/app/views/examples/index.html.erb
+++ b/demo/app/views/examples/index.html.erb
@@ -2,3 +2,5 @@
 <p>You are being recorded</p>
 
 <%= link_to "Pretend you are doing stuff", { action: :new } %>
+<br>
+<%= link_to "Try encountering server error", { action: :error } %>

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
 
   root to: "examples#index"
 
-  resources :examples, only: [ :index, :show, :new, :create ]
+  resources :examples, only: [ :index, :show, :new, :create ] do
+    collection do
+      get :error
+    end
+  end
 end


### PR DESCRIPTION
I though that it may be useful adding path to error page in demo app, for testing around events encountering errors