### PR TITLE
Add ruby version to development Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
+if File.exist?(".ruby-version")
+  ruby file: ".ruby-version"
+end
+
 # Specify your gem's dependencies in spectator_sport.gemspec.
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,5 +316,8 @@ DEPENDENCIES
   sqlite3
   warning
 
+RUBY VERSION
+   ruby 3.3.5p100
+
 BUNDLED WITH
    2.5.18


### PR DESCRIPTION
This is necessary for the Heroku-hosted demo. Once matrixed CI is set up, it's simple enough to delete the `.ruby-version` file and regenerate the lockfile.