### PR TITLE
Session Stores Additional Request Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ To install Spectator Sport in your Rails application:
     bundle add spectator_sport
     ```
 2. Install Spectator Sport in your application. _🚧 This will change on the path to v1._ Explore the `/demo` app as live example:
-    - Create database migrations with `bin/rails g spectator_sport:install:migrations`. Apply migrations with `bin/rails db:prepare`
-    - Mount the recorder API in your application's routes with `mount SpectatorSport::Engine, at: "/spectator_sport, as: :spectator_sport"`
+    - Create database migrations with `bin/rails spectator_sport:install:migrations`. Apply migrations with `bin/rails db:prepare`
+    - Mount the recorder API in your application's routes with `mount SpectatorSport::Engine, at: "spectator_sport", as: :spectator_sport`
     - Add the `spectator_sport_script_tags` helper to the bottom of the `<head>` of `layout/application.rb`. Example:
         ```erb
         <%# app/views/layouts/application.html.erb %>
@@ -55,6 +55,20 @@ To install Spectator Sport in your Rails application:
           <script defer src="/spectator_sport/events.js"></script>
         </head>
         ```
+    - Optional: If you would like to capture referrer and landing path data, add this to your `ApplicationController`:
+        ```rb
+        class ApplicationController < ActionController::Base
+          before_action :store_referrer_and_path
+
+          private
+
+          def store_referrer_and_path
+            session["referrer"] ||= request.referrer.to_s
+            session["landing_path"] ||= request.path.to_s
+          end
+        end
+        ```
+
   3. To view recordings, you will want to mount the Player Dashboard in your application and set up authorization to limit access. See the section on [Dashboard authorization](#dashboard-authorization) for instructions.
 
 ## Dashboard authorization

--- a/app/controllers/spectator_sport/events_controller.rb
+++ b/app/controllers/spectator_sport/events_controller.rb
@@ -17,7 +17,18 @@ module SpectatorSport
       window_secure_id = data["windowId"]
       events = data["events"]
 
-      session = Session.find_or_create_by(secure_id: session_secure_id)
+      spectator_session_params = {
+        remote_ip: request.remote_ip,
+        user_agent: request.user_agent
+      }
+      spectator_session_params[:referrer] = session["referrer"] if session.has_key?("referrer")
+      spectator_session_params[:landing_path] = session["landing_path"] if session.has_key?("landing_path")
+
+      session = Session.create_with(
+        spectator_session_params
+      ).find_or_create_by(
+        secure_id: session_secure_id
+      )
       window = SessionWindow.find_or_create_by(secure_id: window_secure_id, session: session)
 
       records_data = events.map do |event|

--- a/app/views/spectator_sport/dashboard/session_windows/show.html.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/show.html.erb
@@ -16,3 +16,41 @@
     player.$destroy();
   });
 </script>
+
+<div class="container mt-3">
+  <h3>Session Data</h3>
+  <table class="table mb-0">
+    </thead>
+    <tbody>
+      <tr>
+        <th>Created At</th>
+        <td><%= @session_window.session.created_at %></td>
+      </tr>
+      <tr>
+        <th>Created At</th>
+        <td><%= @session_window.session.created_at %></td>
+      </tr>
+      <tr>
+        <th>Secure ID</th>
+        <td><%= @session_window.session.secure_id %></td>
+      </tr>
+      <tr>
+        <th>User Agent</th>
+        <td><%= @session_window.session.user_agent %></td>
+      </tr>
+      <tr>
+        <th>Referrer</th>
+        <td><%= @session_window.session.referrer %></td>
+      </tr>
+      <tr>
+        <th>Remote IP</th>
+        <td><%= @session_window.session.remote_ip %></td>
+      </tr>
+      <tr>
+        <th>Landing Path</th>
+        <td><%= @session_window.session.landing_path %></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+

--- a/db/migrate/20240923140845_create_spectator_sport_events.rb
+++ b/db/migrate/20240923140845_create_spectator_sport_events.rb
@@ -1,8 +1,12 @@
-class CreateSpectatorSportEvents < ActiveRecord::Migration[7.2]
+class CreateSpectatorSportEvents < ActiveRecord::Migration[7.0]
   def change
     create_table :spectator_sport_sessions do |t|
       t.timestamps
       t.string :secure_id, null: false
+      t.string :user_agent
+      t.string :referrer
+      t.string :remote_ip
+      t.string :landing_path
 
       t.index [ :secure_id, :created_at ]
     end
@@ -19,8 +23,8 @@ class CreateSpectatorSportEvents < ActiveRecord::Migration[7.2]
       t.references :session_window, null: true
       t.json :event_data, null: false # TODO: jsonb for postgres ???
 
-      t.index [ :session_id, :created_at ]
-      t.index [ :session_window_id, :created_at ]
+      t.index [ :session_id, :created_at ], name: :index_ss_events_on_session_id_and_created_at
+      t.index [ :session_window_id, :created_at ], name: :index_ss_events_on_session_window_id_and_created_at
     end
   end
 end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -35,6 +35,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_23_140845) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "secure_id", null: false
+    t.string "user_agent"
+    t.string "referrer"
+    t.string "remote_ip"
+    t.string "landing_path"
     t.index [ "secure_id", "created_at" ], name: "index_spectator_sport_sessions_on_secure_id_and_created_at"
   end
 end

--- a/spectator_sport.gemspec
+++ b/spectator_sport.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
     "LICENSE.txt",
   ]
 
-  spec.add_dependency "rails", ">= 7.2.1"
+  spec.add_dependency "rails", ">= 7.0.0"
 end


### PR DESCRIPTION
This adds four pieces of request data to the Session model.

It also includes a few things that I adjusted to make it work in my environment that I didn't feel were deal-breakers:

* Updated the README to have correct installation commands
* Reduced the rails gem requirement from 7.2 to 7.0 (I was testing this on another app in our environment)
* Updated the README with optional instructions for capturing a better referrer / landing page (without it, the landing path is always `/spectator_sport/events.js` and the referrer is always your own site)
* Added Session Data to the Dashboard view
* Explicitly set index names because I was getting "Name too long" errors in my app.

Closes #25 

