### PR TITLE
Paginate events loading on SessionWindow#show

### DIFF
--- a/app/controllers/spectator_sport/dashboard/session_windows_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/session_windows_controller.rb
@@ -3,6 +3,18 @@ module SpectatorSport
     class SessionWindowsController < ApplicationController
       def show
         @session_window = SessionWindow.find(params[:id])
+        @events = @session_window.events.page_after(nil)
+      end
+
+      def events
+        response.content_type = "text/vnd.turbo-stream.html"
+        return head(:ok) if params[:after_event_id].blank?
+
+        session_window = SessionWindow.find(params[:id])
+        previous_event = session_window.events.find_by(id: params[:after_event_id])
+        @events = session_window.events.page_after(previous_event)
+
+        render layout: false
       end
 
       def destroy

--- a/app/frontend/spectator_sport/dashboard/modules/player_controller.js
+++ b/app/frontend/spectator_sport/dashboard/modules/player_controller.js
@@ -5,12 +5,13 @@ import { Player } from  'rrweb-player';
 export default class extends Controller {
   static values = {
     events: { type: Array, default: [] },
-    events_after: { type: Number, default: 0 },
   }
+
+  static targets = [ "player", "events" ]
 
   connect() {
     this.player = new Player({
-      target: this.element,
+      target: this.playerTarget,
       props: {
         events: this.eventsValue,
         liveMode: true,
@@ -27,12 +28,23 @@ export default class extends Controller {
       window.location.hash = seconds;
     });
 
-    const playerElement = this.element.getElementsByClassName("rr-player")[0];
+    const playerElement = this.playerTarget.getElementsByClassName("rr-player")[0];
     playerElement.style.width = "100%";
     playerElement.style.height = null;
     playerElement.style.float = "none"
     playerElement.style["border-radius"] = "inherit";
     playerElement.style["box-shadow"] = "none";
+  }
+
+  eventsTargetConnected(element) {
+    if (!this.player) return;
+
+    const events = JSON.parse(element.dataset.events);
+    events.forEach(event => {
+      this.player.addEvent(event);
+    });
+
+    element.remove();
   }
 
   disconnect() {

--- a/app/models/spectator_sport/event.rb
+++ b/app/models/spectator_sport/event.rb
@@ -1,6 +1,10 @@
 module SpectatorSport
   class Event < ApplicationRecord
+    PAGE_LIMIT = 1_000
+
     belongs_to :session
     belongs_to :session_window
+
+    scope :page_after, ->(event) { (event ? where("(created_at, id) > (?, ?)", event.created_at, event.id) : self).order(created_at: :asc, id: :asc).limit(PAGE_LIMIT) }
   end
 end

--- a/app/views/spectator_sport/dashboard/session_windows/_more_events_frame.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/_more_events_frame.erb
@@ -1,0 +1,1 @@
+<turbo-frame id="more-events" src="<%= url_for(action: :events, format: :turbo_stream, after_event_id: events.last.id) %>"></turbo-frame>

--- a/app/views/spectator_sport/dashboard/session_windows/events.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/events.erb
@@ -1,0 +1,13 @@
+<turbo-stream action="append" target="player">
+  <template>
+    <%= tag.div data: { player_target: "events", events: @events.map(&:event_data).to_json } %>
+  </template>
+</turbo-stream>
+
+<% if @events.size >= SpectatorSport::Event::PAGE_LIMIT %>
+  <turbo-stream action="replace" target="more-events">
+    <template>
+      <%= render "more_events_frame", events: @events %>
+    </template>
+  </turbo-stream>
+<% end %>

--- a/app/views/spectator_sport/dashboard/session_windows/show.html.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/show.html.erb
@@ -1,16 +1,18 @@
-<%
-  events = @session_window.events.order(:created_at)
-  last_event_at = events.last.created_at
-%>
-
 <div class="container mt-3">
   <div class="card">
     <div class="card-body">
-      <%= tag.div "", data: {
+      <%= tag.div id: "player",
+        data: {
+        id: "player",
         controller: "player",
-        player_events_value: events.map(&:event_data).to_json,
-        player_events_after: last_event_at.to_i,
-      } %>
+        player_events_value: @events.map(&:event_data).to_json,
+      } do %>
+        <div data-player-target="player"></div>
+
+        <% if @events.size >= SpectatorSport::Event::PAGE_LIMIT %>
+          <%= render "more_events_frame", events: @events %>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/dashboard_routes.rb
+++ b/config/dashboard_routes.rb
@@ -1,6 +1,10 @@
 SpectatorSport::Dashboard::Engine.routes.draw do
   root to: "dashboards#index"
-  resources :session_windows, only: [ :show, :destroy ]
+  resources :session_windows, only: [ :show, :destroy ] do
+    member do
+      get :events
+    end
+  end
 
   scope :frontend, controller: :frontends, defaults: { version: SpectatorSport::VERSION.tr(".", "-") } do
     get "modules/:version/:id", action: :module, as: :frontend_module, constraints: { format: "js" }


### PR DESCRIPTION
Fixes #43. 

I'll admit, it's a little goofy loading data through the DOM when it could be done with fetch.js. But it seemed like it would be the least different way to do it for the moment. 

Also, this is good learning for how to to turbo without turbo-rails.