### PR TITLE
Feature: stop recording helper to pause recording on specific pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ This renders a hidden `<meta>` element signed by the server. The recording clien
 
 **Note:** this requires the `spectator_sport_session_window_tags` migration to be applied (`bin/rails spectator_sport:install:migrations && bin/rails db:migrate`). If the migration hasn't been run, the feature is silently disabled.
 
+## Stopping recording
+
+You can pause recording for a page by calling `spectator_sport_stop_recording` in any template:
+
+```erb
+<%= spectator_sport_stop_recording %>
+```
+
+This renders a hidden `<meta>` element that the recording client detects on page load. When present, rrweb recording is stopped and no events are buffered or sent. Recording automatically resumes when the user navigates to a page that does not have this tag.
+
+This is useful when navigating via Turbo to pages that shouldn't be recorded — without this tag the recorder would continue running across navigations.
+
 ## Dashboard authorization
 
 It is advisable to manually install and set up authorization for the **Player Dashboard** and refrain from making it public. 

--- a/app/helpers/spectator_sport/script_helper.rb
+++ b/app/helpers/spectator_sport/script_helper.rb
@@ -8,5 +8,9 @@ module SpectatorSport
       signed = Rails.application.message_verifier(:spectator_sport_tag_recording).generate(tag_value)
       tag.meta(name: "spectator-sport-recording-tag", content: signed)
     end
+
+    def spectator_sport_stop_recording
+      tag.meta(name: "spectator-sport-stop-recording")
+    end
   end
 end

--- a/app/helpers/spectator_sport/script_helper.rb
+++ b/app/helpers/spectator_sport/script_helper.rb
@@ -10,7 +10,7 @@ module SpectatorSport
     end
 
     def spectator_sport_stop_recording
-      tag.meta(name: "spectator-sport-stop-recording")
+      tag.meta(name: "spectator-sport-stop")
     end
   end
 end

--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -222,15 +222,62 @@ class TagWatcher {
   }
 }
 
+class StopWatcher {
+  constructor(recorder) {
+    this.recorder = recorder;
+    this.observer = null;
+  }
+
+  start() {
+    this.observer = new MutationObserver((mutations) => {
+      let changed = false;
+      for (const mutation of mutations) {
+        for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
+          if (node.nodeType !== Node.ELEMENT_NODE) continue;
+          if (node.matches('meta[name="spectator-sport-stop-recording"]') ||
+              node.querySelector('meta[name="spectator-sport-stop-recording"]')) {
+            changed = true;
+          }
+        }
+      }
+      if (changed) {
+        this.update();
+      }
+    });
+    this.observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  update() {
+    if (document.querySelector('meta[name="spectator-sport-stop-recording"]')) {
+      this.recorder.stop();
+    } else {
+      this.recorder.start();
+    }
+  }
+}
+
+function isStopped() {
+  return !!document.querySelector('meta[name="spectator-sport-stop-recording"]');
+}
+
 const recorder = new Recorder();
-recorder.start();
+if (!isStopped()) {
+  recorder.start();
+}
 
 const tagWatcher = new TagWatcher(recorder.sessionId, recorder.windowId);
 tagWatcher.start();
 
+const stopWatcher = new StopWatcher(recorder);
+stopWatcher.start();
+
 window.addEventListener("pageshow", function(_event) {
   log("pageshow");
-  recorder.start();
+  if (isStopped()) {
+    recorder.stop();
+  } else {
+    recorder.start();
+  }
 });
 
 window.addEventListener("pagehide", function(_event) {
@@ -241,7 +288,9 @@ window.addEventListener("pagehide", function(_event) {
 document.addEventListener("visibilitychange", function(_event) {
   log("visibilitychange", document.visibilityState);
   if (document.visibilityState === "visible") {
-    recorder.unpause();
+    if (!isStopped()) {
+      recorder.unpause();
+    }
   } else if (document.visibilityState === "hidden") {
     recorder.pause();
   }

--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -234,8 +234,8 @@ class StopWatcher {
       for (const mutation of mutations) {
         for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
           if (node.nodeType !== Node.ELEMENT_NODE) continue;
-          if (node.matches('meta[name="spectator-sport-stop-recording"]') ||
-              node.querySelector('meta[name="spectator-sport-stop-recording"]')) {
+          if (node.matches('meta[name="spectator-sport-stop"]') ||
+              node.querySelector('meta[name="spectator-sport-stop"]')) {
             changed = true;
           }
         }
@@ -248,7 +248,7 @@ class StopWatcher {
   }
 
   update() {
-    if (document.querySelector('meta[name="spectator-sport-stop-recording"]')) {
+    if (document.querySelector('meta[name="spectator-sport-stop"]')) {
       this.recorder.stop();
     } else {
       this.recorder.start();
@@ -257,7 +257,7 @@ class StopWatcher {
 }
 
 function isStopped() {
-  return !!document.querySelector('meta[name="spectator-sport-stop-recording"]');
+  return !!document.querySelector('meta[name="spectator-sport-stop"]');
 }
 
 const recorder = new Recorder();

--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -29,6 +29,8 @@ function log(...args) {
 const POST_URL = new URL("./events", document.currentScript.src).href;
 const POST_INTERVAL_SECONDS = 15;
 const KEEPALIVE_BYTE_LIMIT = 60000; // Fetch payloads >64kb cannot use keepalive: true
+const RECORDING_TAG_SELECTOR = 'meta[name="spectator-sport-recording-tag"]';
+const STOP_SELECTOR = 'meta[name="spectator-sport-stop"]';
 
 class Recorder {
   constructor() {
@@ -173,7 +175,7 @@ class TagWatcher {
   }
 
   start() {
-    document.querySelectorAll('meta[name="spectator-sport-recording-tag"]').forEach(el => {
+    document.querySelectorAll(RECORDING_TAG_SELECTOR).forEach(el => {
       this.enqueue(el.content);
     });
 
@@ -181,10 +183,10 @@ class TagWatcher {
       for (const mutation of mutations) {
         for (const node of mutation.addedNodes) {
           if (node.nodeType !== Node.ELEMENT_NODE) continue;
-          if (node.matches('meta[name="spectator-sport-recording-tag"]')) {
+          if (node.matches(RECORDING_TAG_SELECTOR)) {
             this.enqueue(node.content);
           }
-          node.querySelectorAll('meta[name="spectator-sport-recording-tag"]').forEach(el => {
+          node.querySelectorAll(RECORDING_TAG_SELECTOR).forEach(el => {
             this.enqueue(el.content);
           });
         }
@@ -234,8 +236,8 @@ class StopWatcher {
       for (const mutation of mutations) {
         for (const node of [...mutation.addedNodes, ...mutation.removedNodes]) {
           if (node.nodeType !== Node.ELEMENT_NODE) continue;
-          if (node.matches('meta[name="spectator-sport-stop"]') ||
-              node.querySelector('meta[name="spectator-sport-stop"]')) {
+          if (node.matches(STOP_SELECTOR) ||
+              node.querySelector(STOP_SELECTOR)) {
             changed = true;
           }
         }
@@ -248,7 +250,7 @@ class StopWatcher {
   }
 
   update() {
-    if (document.querySelector('meta[name="spectator-sport-stop"]')) {
+    if (document.querySelector(STOP_SELECTOR)) {
       this.recorder.stop();
     } else {
       this.recorder.start();
@@ -257,7 +259,7 @@ class StopWatcher {
 }
 
 function isStopped() {
-  return !!document.querySelector('meta[name="spectator-sport-stop"]');
+  return !!document.querySelector(STOP_SELECTOR);
 }
 
 const recorder = new Recorder();

--- a/demo/app/views/examples/stopped.html.erb
+++ b/demo/app/views/examples/stopped.html.erb
@@ -1,0 +1,3 @@
+<%= spectator_sport_stop_recording %>
+<p>Recording is stopped on this page.</p>
+<%= link_to "Go back to recording", examples_path %>

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :examples, only: [ :index, :show, :new, :create ] do
     collection do
       get :error
+      get :stopped
     end
   end
 end

--- a/spec/system/stop_recording_spec.rb
+++ b/spec/system/stop_recording_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Stop recording", type: :system, js: true do
+  it "does not record when stop recording tag is present" do
+    expect {
+      visit "/examples/stopped"
+      visit "/spectator_sport_dashboard"
+    }.not_to change { SpectatorSport::SessionWindow.count }
+  end
+
+  it "resumes recording after navigating away from a stopped page" do
+    visit "/examples/stopped"
+    visit "/examples"
+
+    # Navigate away to trigger pagehide, which flushes events
+    visit "/spectator_sport_dashboard"
+
+    page.document.synchronize(Capybara.default_max_wait_time) do
+      raise Capybara::ElementNotFound, "session window not stored yet" unless SpectatorSport::SessionWindow.exists?
+    end
+
+    expect(SpectatorSport::SessionWindow.count).to be > 0
+  end
+end


### PR DESCRIPTION
Adds a `spectator_sport_stop_recording` view helper that outputs a `<meta name="spectator-sport-stop">` tag. When this tag is present on a page, rrweb recording is stopped and no events are buffered or sent to the server. Recording automatically resumes when the user navigates to a page without the tag.

A `StopWatcher` class using `MutationObserver` handles Turbo Drive navigations (where `pageshow` does not fire), detecting when the stop tag is added or removed from the DOM mid-session. The `pageshow` and `visibilitychange` handlers are also updated to respect the stop tag.

Includes a demo route/view and system tests verifying that visiting a stopped page creates no session windows and that recording resumes after navigating away.