### PR TITLE
Feature: label recordings with key/value pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ This renders a hidden `<meta>` element signed by the server. The recording clien
 
 **Note:** this requires the `spectator_sport_session_window_tags` migration to be applied (`bin/rails spectator_sport:install:migrations && bin/rails db:migrate`). If the migration hasn't been run, the feature is silently disabled.
 
+## Labeling recordings
+
+You can associate key-value labels with the current recording by calling `spectator_sport_label_recording` in any template:
+
+```erb
+<%= spectator_sport_label_recording(current_user.id.to_s, key: "user_id", strategy: :one) %>
+<%= spectator_sport_label_recording("admin", key: "role", strategy: :many) %>
+<%= spectator_sport_label_recording("vip") %>
+```
+
+The `key` argument is optional. When omitted, the label behaves like a tag. The `strategy` argument (default `:many`) controls how values are stored per recording:
+
+- `strategy: :many` (default): multiple values for the same key are accumulated per recording.
+- `strategy: :one`: only one value per key is kept per recording. A later call with the same key replaces the stored value. Without a key, behaves like `:many`.
+- `strategy: :first`: only the first value for a key is stored; subsequent calls with the same key are ignored. Requires a key.
+
+This renders a hidden `<meta>` element signed by the server. The recording client detects it and immediately sends it to the API, where the signature is verified before the label is stored. Labels are displayed in the dashboard and can be used to look up all recordings associated with a given key-value pair.
+
+**Note:** this requires the `spectator_sport_labels` migration to be applied (`bin/rails spectator_sport:install:migrations && bin/rails db:migrate`). If the migration hasn't been run, the feature is silently disabled.
+
 ## Stopping recording
 
 You can pause recording for a page by calling `spectator_sport_stop_recording` in any template:

--- a/app/controllers/spectator_sport/dashboard/dashboards_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/dashboards_controller.rb
@@ -4,6 +4,7 @@ module SpectatorSport
       def index
         @session_windows = SessionWindow.order(:created_at).limit(50).reverse_order
         @session_windows = @session_windows.includes(:session_window_tags) if SpectatorSport::SessionWindowTag.migrated?
+        @session_windows = @session_windows.includes(:labels) if SpectatorSport::Label.migrated?
       end
     end
   end

--- a/app/controllers/spectator_sport/dashboard/labels_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/labels_controller.rb
@@ -1,0 +1,37 @@
+module SpectatorSport
+  module Dashboard
+    class LabelsController < ApplicationController
+      def tags
+        @value = params[:value]
+        @session_windows = session_windows_scope
+          .where(spectator_sport_labels: { key: nil, value: @value })
+      end
+
+      def key_index
+        @key = params[:key]
+        @session_windows = session_windows_scope
+          .where(spectator_sport_labels: { key: @key })
+      end
+
+      def show
+        @key = params[:key]
+        @value = params[:value]
+        @session_windows = session_windows_scope
+          .where(spectator_sport_labels: { key: @key, value: @value })
+      end
+
+      private
+
+      def session_windows_scope
+        scope = SessionWindow
+          .joins(:labels)
+          .distinct
+          .order(updated_at: :desc)
+          .limit(50)
+        scope = scope.includes(:session_window_tags) if SpectatorSport::SessionWindowTag.migrated?
+        scope = scope.includes(:labels) if SpectatorSport::Label.migrated?
+        scope
+      end
+    end
+  end
+end

--- a/app/controllers/spectator_sport/dashboard/session_windows_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/session_windows_controller.rb
@@ -5,6 +5,7 @@ module SpectatorSport
         @session_window = SessionWindow.find(params[:id])
         @events = @session_window.events.page_after(nil)
         @tags = SpectatorSport::SessionWindowTag.migrated? ? @session_window.session_window_tags.to_a : []
+        @labels = SpectatorSport::Label.migrated? ? @session_window.labels.to_a : []
       end
 
       def events
@@ -25,6 +26,8 @@ module SpectatorSport
       def destroy
         @session_window = SessionWindow.find(params[:id])
         @session_window.events.delete_all
+        @session_window.session_window_tags.delete_all if SpectatorSport::SessionWindowTag.migrated?
+        @session_window.labels.delete_all if SpectatorSport::Label.migrated?
         @session_window.delete
 
         redirect_to root_path

--- a/app/controllers/spectator_sport/events_controller.rb
+++ b/app/controllers/spectator_sport/events_controller.rb
@@ -7,10 +7,10 @@ module SpectatorSport
 
     def create
       data = if params.key?(:sessionId) && params.key?(:windowId) && params.key?(:events)
-        params.slice(:sessionId, :windowId, :events, :tags).stringify_keys
+        params.slice(:sessionId, :windowId, :events, :tags, :labels).stringify_keys
       else
         # beacon sends JSON in the request body
-        JSON.parse(request.body.read).slice("sessionId", "windowId", "events", "tags")
+        JSON.parse(request.body.read).slice("sessionId", "windowId", "events", "tags", "labels")
       end
 
       session_secure_id = data["sessionId"]
@@ -35,6 +35,22 @@ module SpectatorSport
           next unless tag_value.is_a?(String) && tag_value.present?
           SessionWindowTag.find_or_create_by(session_window: window, tag: tag_value)
         rescue ActiveRecord::RecordNotUnique
+          nil
+        end
+      end
+
+      if SpectatorSport::Label.migrated?
+        verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
+        Array(data["labels"]).first(20).each do |signed_label|
+          label_data = verifier.verified(signed_label)
+          next unless label_data.is_a?(Hash)
+          Label.record(
+            session_window: window,
+            value: label_data["value"],
+            key: label_data["key"],
+            strategy: label_data["strategy"]
+          )
+        rescue StandardError
           nil
         end
       end

--- a/app/helpers/spectator_sport/script_helper.rb
+++ b/app/helpers/spectator_sport/script_helper.rb
@@ -9,6 +9,12 @@ module SpectatorSport
       tag.meta(name: "spectator-sport-recording-tag", content: signed)
     end
 
+    def spectator_sport_label_recording(value, key: nil, strategy: :many)
+      label_data = { value: value, key: key, strategy: strategy.to_s }
+      signed = Rails.application.message_verifier(:spectator_sport_label_recording).generate(label_data)
+      tag.meta(name: "spectator-sport-recording-label", content: signed)
+    end
+
     def spectator_sport_stop_recording
       tag.meta(name: "spectator-sport-stop")
     end

--- a/app/models/spectator_sport/label.rb
+++ b/app/models/spectator_sport/label.rb
@@ -1,0 +1,54 @@
+module SpectatorSport
+  class Label < ApplicationRecord
+    self.table_name = "spectator_sport_labels"
+
+    belongs_to :session_window
+    validates :value, presence: true
+
+    def self.migrated?
+      return true if table_exists?
+
+      Rails.logger.warn "SpectatorSport: pending migration for spectator_sport_labels table. Run: rails spectator_sport:install:migrations && rails db:migrate"
+      false
+    end
+
+    def self.record(session_window:, value:, key: nil, strategy: "many")
+      value = value.to_s.presence
+      key = key.to_s.presence
+      strategy = key ? strategy.to_s : "many"
+      return unless value
+
+      case strategy
+      when "first"
+        mysql_lock(session_window) do
+          find_or_create_by(session_window: session_window, key: key) do |l|
+            l.value = value
+            l.multiple = false
+          end
+        end
+      when "one"
+        mysql_lock(session_window) do
+          label = find_or_initialize_by(session_window: session_window, key: key)
+          label.assign_attributes(value: value, multiple: false)
+          label.save
+        end
+      else # "many"
+        find_or_create_by(session_window: session_window, key: key, value: value) do |l|
+          l.multiple = true
+        end
+      end
+    end
+
+    def self.mysql_lock(session_window, &block)
+      if connection.adapter_name =~ /mysql/i
+        session_window.with_lock(&block)
+      else
+        block.call
+      end
+    end
+
+    def display
+      key.present? ? "#{key}: #{value}" : value
+    end
+  end
+end

--- a/app/models/spectator_sport/session_window.rb
+++ b/app/models/spectator_sport/session_window.rb
@@ -1,8 +1,9 @@
 module SpectatorSport
   class SessionWindow < ApplicationRecord
     belongs_to :session
-    has_many :events
-    has_many :session_window_tags
+    has_many :events, dependent: :delete_all
+    has_many :session_window_tags, dependent: :delete_all
+    has_many :labels, class_name: "SpectatorSport::Label", dependent: :delete_all
 
     def analysis
       @analysis ||= SessionWindowAnalysis.new(self)

--- a/app/views/spectator_sport/dashboard/labels/key_index.html.erb
+++ b/app/views/spectator_sport/dashboard/labels/key_index.html.erb
@@ -1,7 +1,8 @@
 <div class="container my-3">
-  <% if @session_windows.to_a.any? %>
+  <h2>Recordings with label key: <%= @key %></h2>
+  <% if @session_windows.any? %>
     <%= render "spectator_sport/dashboard/shared/session_windows", session_windows: @session_windows %>
   <% else %>
-    <em>No recordings found.</em>
+    <em>No recordings found with label key "<%= @key %>".</em>
   <% end %>
 </div>

--- a/app/views/spectator_sport/dashboard/labels/show.html.erb
+++ b/app/views/spectator_sport/dashboard/labels/show.html.erb
@@ -1,0 +1,9 @@
+<div class="container my-3">
+  <h2>Recordings labeled: <%= @key %>: <%= @value %></h2>
+  <p><%= link_to "See all recordings with key: #{@key}", label_key_path(@key) %></p>
+  <% if @session_windows.any? %>
+    <%= render "spectator_sport/dashboard/shared/session_windows", session_windows: @session_windows %>
+  <% else %>
+    <em>No recordings found with label "<%= @key %>: <%= @value %>".</em>
+  <% end %>
+</div>

--- a/app/views/spectator_sport/dashboard/labels/tags.html.erb
+++ b/app/views/spectator_sport/dashboard/labels/tags.html.erb
@@ -1,7 +1,8 @@
 <div class="container my-3">
-  <% if @session_windows.to_a.any? %>
+  <h2>Recordings labeled: <%= @value %></h2>
+  <% if @session_windows.any? %>
     <%= render "spectator_sport/dashboard/shared/session_windows", session_windows: @session_windows %>
   <% else %>
-    <em>No recordings found.</em>
+    <em>No recordings found with label "<%= @value %>".</em>
   <% end %>
 </div>

--- a/app/views/spectator_sport/dashboard/session_windows/show.html.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/show.html.erb
@@ -22,11 +22,45 @@
       <% end %>
     </div>
   </div>
-  <% if @tags.any? %>
-    <div class="d-flex justify-content-center pt-2 gap-2">
-      <% @tags.each do |swt| %>
-        <%= link_to swt.tag, tag_path(swt.tag), class: "badge text-bg-secondary text-decoration-none" %>
-      <% end %>
+  <% keyed_labels = @labels.select { |l| l.key.present? }.group_by(&:key) %>
+  <% tag_values = @tags.map(&:tag) %>
+  <% keyless_labels = @labels.select { |l| l.key.nil? }.map(&:value) %>
+  <% if keyed_labels.any? || tag_values.any? || keyless_labels.any? %>
+    <div class="card mt-3">
+      <div class="card-header">Labels</div>
+      <table class="table table-sm mb-0">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% keyed_labels.each do |key, labels| %>
+            <tr>
+              <td><%= link_to key, label_key_path(key) %></td>
+              <td>
+                <% labels.each do |label| %>
+                  <%= link_to label.value, label_path(label.key, label.value) %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+          <% if tag_values.any? || keyless_labels.any? %>
+            <tr>
+              <td>Tags</td>
+              <td>
+                <% tag_values.each do |tv| %>
+                  <%= link_to tv, tag_path(tv) %>
+                <% end %>
+                <% keyless_labels.each do |lv| %>
+                  <%= link_to lv, label_tag_path(lv) %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
     </div>
   <% end %>
   <div class="d-flex justify-content-center pt-2">

--- a/app/views/spectator_sport/dashboard/shared/_session_windows.html.erb
+++ b/app/views/spectator_sport/dashboard/shared/_session_windows.html.erb
@@ -1,0 +1,63 @@
+<div class="card">
+  <table class="table">
+    <caption class="visually-hidden">List of screen recordings</caption>
+    <thead>
+    <tr>
+      <th>Recording</th>
+      <th>Session ID</th>
+      <% if SpectatorSport::SessionWindowTag.migrated? %>
+        <th>Tags</th>
+      <% end %>
+      <% if SpectatorSport::Label.migrated? %>
+        <th>Labels</th>
+      <% end %>
+      <th>Updated</th>
+      <th>Created</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% session_windows.each do |session_window| %>
+      <tr>
+        <td><%= link_to "Session (Window ##{session_window.id})", session_window_path(session_window.id) %></td>
+        <td><%= session_window.session_id %></td>
+        <% if SpectatorSport::SessionWindowTag.migrated? %>
+          <td>
+            <% session_window.session_window_tags.each do |swt| %>
+              <%= link_to swt.tag, tag_path(swt.tag) %>
+            <% end %>
+          </td>
+        <% end %>
+        <% if SpectatorSport::Label.migrated? %>
+          <td>
+            <% session_window.labels.each do |swl| %>
+              <% if swl.key.present? %>
+                <%= link_to swl.key, label_key_path(swl.key) %>
+                <%= link_to swl.display, label_path(swl.key, swl.value) %>
+              <% else %>
+                <%= link_to swl.value, label_tag_path(swl.value) %>
+              <% end %>
+            <% end %>
+          </td>
+        <% end %>
+        <td><%= tag.time(time_ago_in_words(session_window.updated_at), datetime: session_window.updated_at, title: session_window.updated_at) %>
+        <td><%= tag.time(time_ago_in_words(session_window.created_at), datetime: session_window.created_at, title: session_window.created_at) %>
+        <td>
+          <button class="d-flex align-items-center btn btn-sm" type="button" id="<%= dom_id(session_window, :actions) %>" data-bs-toggle="dropdown" aria-expanded="false">
+            <%= render_icon "dots" %>
+            <span class="visually-hidden">Actions</span>
+          </button>
+          <ul class="dropdown-menu shadow" aria-labelledby="<%= dom_id(session_window, :actions) %>">
+            <li>
+              <%= link_to session_window_path(session_window.id), method: :put, class: "dropdown-item", title: "Destroy", data: { "turbo-method": :delete, "turbo-confirm": "Destroy this recording?" } do %>
+                <%= render_icon "eject" %>
+                Destroy
+              <% end %>
+            </li>
+          </ul>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -30,6 +30,7 @@ const POST_URL = new URL("./events", document.currentScript.src).href;
 const POST_INTERVAL_SECONDS = 15;
 const KEEPALIVE_BYTE_LIMIT = 60000; // Fetch payloads >64kb cannot use keepalive: true
 const RECORDING_TAG_SELECTOR = 'meta[name="spectator-sport-recording-tag"]';
+const RECORDING_LABEL_SELECTOR = 'meta[name="spectator-sport-recording-label"]';
 const STOP_SELECTOR = 'meta[name="spectator-sport-stop"]';
 
 class Recorder {
@@ -224,6 +225,66 @@ class TagWatcher {
   }
 }
 
+class LabelWatcher {
+  constructor(sessionId, windowId) {
+    this.sessionId = sessionId;
+    this.windowId = windowId;
+    this.seenLabels = new Set();
+    this.pendingLabels = [];
+    this.debounceTimeout = null;
+    this.observer = null;
+  }
+
+  start() {
+    document.querySelectorAll(RECORDING_LABEL_SELECTOR).forEach(el => {
+      this.enqueue(el.content);
+    });
+
+    this.observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node.nodeType !== Node.ELEMENT_NODE) continue;
+          if (node.matches(RECORDING_LABEL_SELECTOR)) {
+            this.enqueue(node.content);
+          }
+          node.querySelectorAll(RECORDING_LABEL_SELECTOR).forEach(el => {
+            this.enqueue(el.content);
+          });
+        }
+      }
+    });
+    this.observer.observe(document.documentElement, { childList: true, subtree: true });
+  }
+
+  enqueue(signedLabel) {
+    if (this.seenLabels.has(signedLabel)) return;
+    this.seenLabels.add(signedLabel);
+    this.pendingLabels.push(signedLabel);
+    this.debouncedFlush();
+  }
+
+  debouncedFlush() {
+    if (!this.debounceTimeout) {
+      this.debounceTimeout = setTimeout(() => {
+        this.debounceTimeout = null;
+        this.flush();
+      }, 100);
+    }
+  }
+
+  flush() {
+    if (this.pendingLabels.length === 0) return;
+    const labels = this.pendingLabels.splice(0);
+    fetch(POST_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId: this.sessionId, windowId: this.windowId, events: [], labels }),
+    }).catch((error) => {
+      console.error(error);
+    });
+  }
+}
+
 class StopWatcher {
   constructor(recorder) {
     this.recorder = recorder;
@@ -269,6 +330,9 @@ if (!isStopped()) {
 
 const tagWatcher = new TagWatcher(recorder.sessionId, recorder.windowId);
 tagWatcher.start();
+
+const labelWatcher = new LabelWatcher(recorder.sessionId, recorder.windowId);
+labelWatcher.start();
 
 const stopWatcher = new StopWatcher(recorder);
 stopWatcher.start();

--- a/config/dashboard_routes.rb
+++ b/config/dashboard_routes.rb
@@ -7,6 +7,9 @@ SpectatorSport::Dashboard::Engine.routes.draw do
     end
   end
   resources :tags, only: [ :show ], param: :name
+  get "labels/tags/:value", to: "labels#tags", as: :label_tag
+  get "labels/keys/:key", to: "labels#key_index", as: :label_key
+  get "labels/keys/:key/:value", to: "labels#show", as: :label
 
   scope :frontend, controller: :frontends, defaults: { version: SpectatorSport::VERSION.tr(".", "-") } do
     get "modules/:version/:id", action: :module, as: :frontend_module, constraints: { format: "js" }

--- a/db/migrate/20260413000001_create_spectator_sport_labels.rb
+++ b/db/migrate/20260413000001_create_spectator_sport_labels.rb
@@ -1,0 +1,22 @@
+class CreateSpectatorSportLabels < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spectator_sport_labels do |t|
+      t.timestamps
+      t.references :session_window, null: false
+      t.string :key
+      t.string :value, null: false
+      t.boolean :multiple, null: false, default: true
+
+      t.index [ :session_window_id, :key, :value ]
+      t.index [ :key, :value ]
+    end
+
+    unless connection.adapter_name =~ /mysql/i
+      add_index :spectator_sport_labels,
+        [ :session_window_id, :key ],
+        unique: true,
+        where: "multiple = false AND key IS NOT NULL",
+        name: "index_labels_unique_singular_key_per_window"
+    end
+  end
+end

--- a/demo/app/views/examples/index.html.erb
+++ b/demo/app/views/examples/index.html.erb
@@ -1,4 +1,9 @@
 <%= spectator_sport_tag_recording("user-27") %>
+<%= spectator_sport_label_recording("27", key: "user_id", strategy: :one) %>
+<%= spectator_sport_label_recording("admin", key: "role", strategy: :many) %>
+<%= spectator_sport_label_recording("moderator", key: "role", strategy: :many) %>
+<%= spectator_sport_label_recording("index", key: "first_page", strategy: :first) %>
+<%= spectator_sport_label_recording("vip") %>
 <p>This is an example page to demonstrate <strong>Spectator Sport</strong></p>
 <p>Your browser activity is being recorded.</p>
 

--- a/demo/app/views/examples/new.html.erb
+++ b/demo/app/views/examples/new.html.erb
@@ -1,3 +1,5 @@
+<%= spectator_sport_label_recording("28", key: "user_id", strategy: :one) %>
+<%= spectator_sport_label_recording("new", key: "first_page", strategy: :first) %>
 <%= form_with model: @resource, url: { action: :create }, action: :post do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -17,10 +17,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
     t.integer "session_id", null: false
     t.integer "session_window_id"
     t.datetime "updated_at", null: false
-    t.index ["session_id", "created_at"], name: "index_spectator_sport_events_on_session_id_and_created_at"
-    t.index ["session_id"], name: "index_spectator_sport_events_on_session_id"
-    t.index ["session_window_id", "created_at"], name: "idx_on_session_window_id_created_at_f1aab0a880"
-    t.index ["session_window_id"], name: "index_spectator_sport_events_on_session_window_id"
+    t.index [ "session_id", "created_at" ], name: "index_spectator_sport_events_on_session_id_and_created_at"
+    t.index [ "session_id" ], name: "index_spectator_sport_events_on_session_id"
+    t.index [ "session_window_id", "created_at" ], name: "idx_on_session_window_id_created_at_f1aab0a880"
+    t.index [ "session_window_id" ], name: "index_spectator_sport_events_on_session_window_id"
   end
 
   create_table "spectator_sport_labels", force: :cascade do |t|
@@ -30,10 +30,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
     t.integer "session_window_id", null: false
     t.datetime "updated_at", null: false
     t.string "value", null: false
-    t.index ["key", "value"], name: "index_spectator_sport_labels_on_key_and_value"
-    t.index ["session_window_id", "key", "value"], name: "idx_on_session_window_id_key_value_98301751dd"
-    t.index ["session_window_id", "key"], name: "index_labels_unique_singular_key_per_window", unique: true, where: "multiple = false AND key IS NOT NULL"
-    t.index ["session_window_id"], name: "index_spectator_sport_labels_on_session_window_id"
+    t.index [ "key", "value" ], name: "index_spectator_sport_labels_on_key_and_value"
+    t.index [ "session_window_id", "key", "value" ], name: "idx_on_session_window_id_key_value_98301751dd"
+    t.index [ "session_window_id", "key" ], name: "index_labels_unique_singular_key_per_window", unique: true, where: "multiple = false AND key IS NOT NULL"
+    t.index [ "session_window_id" ], name: "index_spectator_sport_labels_on_session_window_id"
   end
 
   create_table "spectator_sport_session_window_tags", force: :cascade do |t|
@@ -41,8 +41,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
     t.integer "session_window_id", null: false
     t.string "tag", null: false
     t.datetime "updated_at", null: false
-    t.index ["session_window_id", "tag"], name: "idx_on_session_window_id_tag_920317ef54", unique: true
-    t.index ["session_window_id"], name: "index_spectator_sport_session_window_tags_on_session_window_id"
+    t.index [ "session_window_id", "tag" ], name: "idx_on_session_window_id_tag_920317ef54", unique: true
+    t.index [ "session_window_id" ], name: "index_spectator_sport_session_window_tags_on_session_window_id"
   end
 
   create_table "spectator_sport_session_windows", force: :cascade do |t|
@@ -50,13 +50,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
     t.string "secure_id", null: false
     t.integer "session_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["session_id"], name: "index_spectator_sport_session_windows_on_session_id"
+    t.index [ "session_id" ], name: "index_spectator_sport_session_windows_on_session_id"
   end
 
   create_table "spectator_sport_sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "secure_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["secure_id", "created_at"], name: "index_spectator_sport_sessions_on_secure_id_and_created_at"
+    t.index [ "secure_id", "created_at" ], name: "index_spectator_sport_sessions_on_secure_id_and_created_at"
   end
 end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,17 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_03_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_000001) do
   create_table "spectator_sport_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.json "event_data", null: false
     t.integer "session_id", null: false
     t.integer "session_window_id"
     t.datetime "updated_at", null: false
-    t.index [ "session_id", "created_at" ], name: "index_spectator_sport_events_on_session_id_and_created_at"
-    t.index [ "session_id" ], name: "index_spectator_sport_events_on_session_id"
-    t.index [ "session_window_id", "created_at" ], name: "idx_on_session_window_id_created_at_f1aab0a880"
-    t.index [ "session_window_id" ], name: "index_spectator_sport_events_on_session_window_id"
+    t.index ["session_id", "created_at"], name: "index_spectator_sport_events_on_session_id_and_created_at"
+    t.index ["session_id"], name: "index_spectator_sport_events_on_session_id"
+    t.index ["session_window_id", "created_at"], name: "idx_on_session_window_id_created_at_f1aab0a880"
+    t.index ["session_window_id"], name: "index_spectator_sport_events_on_session_window_id"
+  end
+
+  create_table "spectator_sport_labels", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "key"
+    t.boolean "multiple", default: true, null: false
+    t.integer "session_window_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "value", null: false
+    t.index ["key", "value"], name: "index_spectator_sport_labels_on_key_and_value"
+    t.index ["session_window_id", "key", "value"], name: "idx_on_session_window_id_key_value_98301751dd"
+    t.index ["session_window_id", "key"], name: "index_labels_unique_singular_key_per_window", unique: true, where: "multiple = false AND key IS NOT NULL"
+    t.index ["session_window_id"], name: "index_spectator_sport_labels_on_session_window_id"
   end
 
   create_table "spectator_sport_session_window_tags", force: :cascade do |t|
@@ -28,8 +41,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_03_000000) do
     t.integer "session_window_id", null: false
     t.string "tag", null: false
     t.datetime "updated_at", null: false
-    t.index [ "session_window_id", "tag" ], name: "idx_on_session_window_id_tag_920317ef54", unique: true
-    t.index [ "session_window_id" ], name: "index_spectator_sport_session_window_tags_on_session_window_id"
+    t.index ["session_window_id", "tag"], name: "idx_on_session_window_id_tag_920317ef54", unique: true
+    t.index ["session_window_id"], name: "index_spectator_sport_session_window_tags_on_session_window_id"
   end
 
   create_table "spectator_sport_session_windows", force: :cascade do |t|
@@ -37,13 +50,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_03_000000) do
     t.string "secure_id", null: false
     t.integer "session_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "session_id" ], name: "index_spectator_sport_session_windows_on_session_id"
+    t.index ["session_id"], name: "index_spectator_sport_session_windows_on_session_id"
   end
 
   create_table "spectator_sport_sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "secure_id", null: false
     t.datetime "updated_at", null: false
-    t.index [ "secure_id", "created_at" ], name: "index_spectator_sport_sessions_on_secure_id_and_created_at"
+    t.index ["secure_id", "created_at"], name: "index_spectator_sport_sessions_on_secure_id_and_created_at"
   end
 end

--- a/spec/app/controllers/dashboard/session_windows_controller_spec.rb
+++ b/spec/app/controllers/dashboard/session_windows_controller_spec.rb
@@ -48,13 +48,13 @@ describe SpectatorSport::Dashboard::SessionWindowsController, type: :controller 
     end
 
     it "deletes associated events" do
-      SpectatorSport::Event.insert_all([{
+      SpectatorSport::Event.insert_all([ {
         session_id: spectator_session.id,
         session_window_id: session_window.id,
         event_data: { "type" => 4 }.to_json,
         created_at: Time.current,
         updated_at: Time.current
-      }])
+      } ])
       event_id = SpectatorSport::Event.where(session_window_id: session_window.id).pick(:id)
 
       delete :destroy, params: { id: session_window.id }

--- a/spec/app/controllers/dashboard/session_windows_controller_spec.rb
+++ b/spec/app/controllers/dashboard/session_windows_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SpectatorSport::Dashboard::SessionWindowsController, type: :controller do
+  render_views
+
+  before do
+    @routes = SpectatorSport::Dashboard::Engine.routes
+  end
+
+  let(:spectator_session) { SpectatorSport::Session.create!(secure_id: "test-session-id") }
+  let(:session_window) { SpectatorSport::SessionWindow.create!(session: spectator_session, secure_id: "test-window-id") }
+
+  describe "GET #show" do
+    it "renders successfully" do
+      get :show, params: { id: session_window.id }
+
+      expect(response).to be_successful
+    end
+
+    it "renders labels when migrated" do
+      SpectatorSport::Label.create!(session_window: session_window, key: "user_id", value: "42", multiple: false)
+
+      get :show, params: { id: session_window.id }
+
+      expect(response.body).to include("user_id")
+      expect(response.body).to include("42")
+    end
+
+    it "renders tags when migrated" do
+      SpectatorSport::SessionWindowTag.create!(session_window: session_window, tag: "test-tag")
+
+      get :show, params: { id: session_window.id }
+
+      expect(response.body).to include("test-tag")
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it "deletes the session window and redirects" do
+      id = session_window.id
+
+      delete :destroy, params: { id: id }
+
+      expect(SpectatorSport::SessionWindow.find_by(id: id)).to be_nil
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "deletes associated events" do
+      SpectatorSport::Event.insert_all([{
+        session_id: spectator_session.id,
+        session_window_id: session_window.id,
+        event_data: { "type" => 4 }.to_json,
+        created_at: Time.current,
+        updated_at: Time.current
+      }])
+      event_id = SpectatorSport::Event.where(session_window_id: session_window.id).pick(:id)
+
+      delete :destroy, params: { id: session_window.id }
+
+      expect(SpectatorSport::Event.find_by(id: event_id)).to be_nil
+    end
+
+    it "deletes associated labels" do
+      label = SpectatorSport::Label.create!(session_window: session_window, key: "env", value: "prod", multiple: false)
+
+      delete :destroy, params: { id: session_window.id }
+
+      expect(SpectatorSport::Label.find_by(id: label.id)).to be_nil
+    end
+
+    it "deletes associated tags" do
+      tag = SpectatorSport::SessionWindowTag.create!(session_window: session_window, tag: "my-tag")
+
+      delete :destroy, params: { id: session_window.id }
+
+      expect(SpectatorSport::SessionWindowTag.find_by(id: tag.id)).to be_nil
+    end
+  end
+end

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -8,6 +8,11 @@ Capybara.server = :puma, { Silent: true }
 Capybara.disable_animation = true # injects CSP-incompatible CSS and JS
 
 module SystemTestHelpers
+  def wait_for_recording
+    # Allow async label/tag watchers to complete: 100ms JS debounce + network round trip
+    sleep(0.3)
+  end
+
   def wait_for_turbo
     return unless Capybara.current_driver != :rack_test
 

--- a/spec/system/recording_labels_spec.rb
+++ b/spec/system/recording_labels_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "stores a keyed label from the page and shows it in the dashboard" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/spectator_sport_dashboard"
     expect(page).to have_text("user_id: 27")
@@ -18,6 +19,7 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "key link from dashboard navigates to key view showing all recordings with that key" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/spectator_sport_dashboard"
     expect(page).to have_text("user_id")
@@ -30,6 +32,7 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "key/value view links back to key view" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/spectator_sport_dashboard"
     expect(page).to have_text("user_id: 27")
@@ -43,6 +46,7 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "stores a keyless label from the page and shows it in the dashboard" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/spectator_sport_dashboard"
     expect(page).to have_text("vip")
@@ -55,6 +59,7 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "strategy: :many stores multiple values for the same key" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     expect(SpectatorSport::Label.where(key: "role", value: "admin")).to exist
     expect(SpectatorSport::Label.where(key: "role", value: "moderator")).to exist
@@ -65,9 +70,11 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "strategy: :one replaces the value when a new value is sent" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/examples/new"
-    expect(page).to have_text("Submit")
+    expect(page).to have_button("Submit")
+    wait_for_recording
 
     session_window = SpectatorSport::Label.where(key: "user_id", value: "28").last.session_window
     expect(session_window.labels.where(key: "user_id").count).to eq(1)
@@ -77,9 +84,11 @@ RSpec.describe "Recording labels", type: :system, js: true do
   it "strategy: :first ignores subsequent values for the same key" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/examples/new"
-    expect(page).to have_text("Submit")
+    expect(page).to have_button("Submit")
+    wait_for_recording
 
     session_window = SpectatorSport::Label.where(key: "first_page", value: "index").last.session_window
     expect(session_window.labels.where(key: "first_page").count).to eq(1)

--- a/spec/system/recording_labels_spec.rb
+++ b/spec/system/recording_labels_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Recording labels", type: :system, js: true do
+  it "stores a keyed label from the page and shows it in the dashboard" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    visit "/spectator_sport_dashboard"
+    expect(page).to have_text("user_id: 27")
+
+    first(:link, "user_id: 27").click
+    expect(page).to have_text("Recordings labeled: user_id: 27")
+    expect(page).to have_css("table")
+  end
+
+  it "key link from dashboard navigates to key view showing all recordings with that key" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    visit "/spectator_sport_dashboard"
+    expect(page).to have_text("user_id")
+
+    first(:link, "user_id").click
+    expect(page).to have_text("Recordings with label key: user_id")
+    expect(page).to have_css("table")
+  end
+
+  it "key/value view links back to key view" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    visit "/spectator_sport_dashboard"
+    expect(page).to have_text("user_id: 27")
+
+    first(:link, "user_id: 27").click
+    expect(page).to have_text("Recordings labeled: user_id: 27")
+    click_link "See all recordings with key: user_id"
+    expect(page).to have_text("Recordings with label key: user_id")
+  end
+
+  it "stores a keyless label from the page and shows it in the dashboard" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    visit "/spectator_sport_dashboard"
+    expect(page).to have_text("vip")
+
+    first(:link, "vip").click
+    expect(page).to have_text("Recordings labeled: vip")
+    expect(page).to have_css("table")
+  end
+
+  it "strategy: :many stores multiple values for the same key" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    expect(SpectatorSport::Label.where(key: "role", value: "admin")).to exist
+    expect(SpectatorSport::Label.where(key: "role", value: "moderator")).to exist
+    session_window = SpectatorSport::Label.where(key: "role", value: "admin").last.session_window
+    expect(session_window.labels.where(key: "role").count).to eq(2)
+  end
+
+  it "strategy: :one replaces the value when a new value is sent" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    visit "/examples/new"
+    expect(page).to have_text("Submit")
+
+    session_window = SpectatorSport::Label.where(key: "user_id", value: "28").last.session_window
+    expect(session_window.labels.where(key: "user_id").count).to eq(1)
+    expect(session_window.labels.where(key: "user_id", value: "27")).not_to exist
+  end
+
+  it "strategy: :first ignores subsequent values for the same key" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+
+    visit "/examples/new"
+    expect(page).to have_text("Submit")
+
+    session_window = SpectatorSport::Label.where(key: "first_page", value: "index").last.session_window
+    expect(session_window.labels.where(key: "first_page").count).to eq(1)
+    expect(session_window.labels.where(key: "first_page", value: "index")).to exist
+    expect(session_window.labels.where(key: "first_page", value: "new")).not_to exist
+  end
+end

--- a/spec/system/recording_tags_spec.rb
+++ b/spec/system/recording_tags_spec.rb
@@ -5,11 +5,7 @@ require "rails_helper"
 RSpec.describe "Recording tags", type: :system, js: true do
   it "stores a tag from the page and shows it in the dashboard" do
     visit "/examples"
-
-    # Wait for JS to detect the meta tag and POST it to the events API
-    page.document.synchronize(Capybara.default_max_wait_time) do
-      raise Capybara::ElementNotFound, "tag not stored yet" unless SpectatorSport::SessionWindowTag.where(tag: "user-27").exists?
-    end
+    expect(page).to have_text("Your browser activity is being recorded.")
 
     visit "/spectator_sport_dashboard"
     expect(page).to have_text("user-27")

--- a/spec/system/recording_tags_spec.rb
+++ b/spec/system/recording_tags_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Recording tags", type: :system, js: true do
   it "stores a tag from the page and shows it in the dashboard" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
+    wait_for_recording
 
     visit "/spectator_sport_dashboard"
     expect(page).to have_text("user-27")

--- a/spec/system/stop_recording_spec.rb
+++ b/spec/system/stop_recording_spec.rb
@@ -16,10 +16,7 @@ RSpec.describe "Stop recording", type: :system, js: true do
 
     # Navigate away to trigger pagehide, which flushes events
     visit "/spectator_sport_dashboard"
-
-    page.document.synchronize(Capybara.default_max_wait_time) do
-      raise Capybara::ElementNotFound, "session window not stored yet" unless SpectatorSport::SessionWindow.exists?
-    end
+    expect(page).to have_text("Spectator Sport")
 
     expect(SpectatorSport::SessionWindow.count).to be > 0
   end


### PR DESCRIPTION
A redo of #59 to add key and value. 

Directionally, I'm moving towards having a single "Recording" object, rather than currently where there is both a Session (representing a Device) and then a Window/Tab. Instead, there will just be "Recordings" of a Window/Tab and it's up to the developer to knit those together using labels into a coherent picture. 

## Description

Adds a `spectator_sport_label_recording` helper that attaches signed key-value labels to recordings via `<meta>` elements detected by a new `LabelWatcher` JS class. Labels support three storage strategies: `:many` (accumulate multiple values per key), `:one` (upsert — replace value for key), and `:first` (store only the first value seen for a key). Keyless labels behave like tags.

Dashboard views let you browse labels at `labels/tags/:value` (keyless), `labels/keys/:key` (all values for a key), and `labels/keys/:key/:value` (specific pair). The session window show page displays a unified Labels table grouping keyed labels by key, with tags and keyless labels in a Tags row. The recordings list table is extracted into a shared partial reused across the dashboard index and all label index views.

Also fixes a bug where `has_many :events` on `SessionWindow` lacked `dependent: :delete_all`, causing session window destruction to nullify event foreign keys instead of deleting them.