### PR TITLE
Fix browser lifecycle hooks: keepalive on pause, skip pageshow on fresh load

### DIFF
--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -79,7 +79,7 @@ class Recorder {
       this.refreshIntervalId = null;
     }
 
-    this.events.transmit();
+    this.events.transmit(true);
   }
 
   unpause() {
@@ -337,8 +337,9 @@ labelWatcher.start();
 const stopWatcher = new StopWatcher(recorder);
 stopWatcher.start();
 
-window.addEventListener("pageshow", function(_event) {
-  log("pageshow");
+window.addEventListener("pageshow", function(event) {
+  log("pageshow", event.persisted);
+  if (!event.persisted) return;
   if (isStopped()) {
     recorder.stop();
   } else {
@@ -346,6 +347,9 @@ window.addEventListener("pageshow", function(_event) {
   }
 });
 
+// Always stop (not pause) on pagehide, even for bfcache (event.persisted=true).
+// stop() forces rrweb to emit a new full snapshot when the page is restored,
+// creating a clean recording segment rather than a seamless continuation.
 window.addEventListener("pagehide", function(_event) {
   log("pagehide");
   recorder.stop();


### PR DESCRIPTION
Two bugs in the Page Lifecycle API event handlers:

`pause()` flushed the event buffer without `keepalive: true`, so the fetch could be cancelled by the browser on navigation. `stop()` then found an empty buffer and skipped its keepalive fetch entirely — meaning the final keepalive was never sent.

`pageshow` called `recorder.start()` on every page load, including fresh loads where the initialization code already called it. Fixed by checking `event.persisted` and returning early when `false`; the handler now only acts on bfcache restores where init code does not re-run.

Also adds a comment explaining why `pagehide` always calls `stop()` rather than `pause()` for bfcache: intentional, to force a new full rrweb snapshot on restore rather than a seamless continuation that obscures the navigation gap.