### PR TITLE
fix(player): handle recordings with no events gracefully

### DIFF
--- a/app/frontend/spectator_sport/dashboard/modules/player_controller.js
+++ b/app/frontend/spectator_sport/dashboard/modules/player_controller.js
@@ -10,6 +10,8 @@ export default class extends Controller {
   static targets = [ "player", "events", "linkUrl" ]
 
   connect() {
+    if (this.eventsValue.length === 0) return;
+
     this.player = new Player({
       target: this.playerTarget,
       props: {

--- a/app/views/spectator_sport/dashboard/session_windows/show.html.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/show.html.erb
@@ -1,24 +1,28 @@
 <div class="container mt-3">
   <div class="card">
     <div class="card-body">
-      <%= tag.div id: "player",
-        data: {
-        id: "player",
-        controller: "player",
-        player_events_value: @events.map(&:event_data).to_json,
-      } do %>
-        <div data-player-target="player"></div>
+      <% if @events.any? %>
+        <%= tag.div id: "player",
+          data: {
+          id: "player",
+          controller: "player",
+          player_events_value: @events.map(&:event_data).to_json,
+        } do %>
+          <div data-player-target="player"></div>
 
-        <div class="mt-3 input-group" data-controller="clipboard">
-          <input type="text" class="form-control form-control-sm" readonly style="max-width: 8rem" data-player-target="linkUrl" data-clipboard-target="source" placeholder="—">
-          <button class="btn btn-sm btn-outline-secondary" data-clipboard-target="button" data-action="click->clipboard#copy">
-            Copy link
-          </button>
-        </div>
+          <div class="mt-3 input-group" data-controller="clipboard">
+            <input type="text" class="form-control form-control-sm" readonly style="max-width: 8rem" data-player-target="linkUrl" data-clipboard-target="source" placeholder="—">
+            <button class="btn btn-sm btn-outline-secondary" data-clipboard-target="button" data-action="click->clipboard#copy">
+              Copy link
+            </button>
+          </div>
 
-        <% if @events.size >= SpectatorSport::Event::PAGE_LIMIT %>
-          <%= render "more_events_frame", events: @events %>
+          <% if @events.size >= SpectatorSport::Event::PAGE_LIMIT %>
+            <%= render "more_events_frame", events: @events %>
+          <% end %>
         <% end %>
+      <% else %>
+        <p class="text-muted mb-0">No recording data available.</p>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- When a recording has no events (e.g. a page with `spectator-sport-stop` that still flushes tags/labels), the dashboard player previously rendered a broken rrweb UI.
- The player Stimulus controller now early-returns if `eventsValue` is empty, preventing rrweb Player from initializing with an empty events array.
- The show view conditionally renders the player only when events exist, showing "No recording data available." otherwise.

## Test plan

- [ ] Visit a recording with events — player renders and plays back normally
- [ ] Visit a recording with no events — "No recording data available." message is shown instead of broken player UI
- [ ] Tags/labels still display correctly on recordings with no events