### PR TITLE
Bundle tags and labels with events payload

### DIFF
--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -216,18 +216,14 @@ class Events {
     if (this.tags.has(signedTag)) return;
     this.tags.add(signedTag);
     this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(signedTag));
-    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT) {
-      this.debouncedTransmit();
-    }
+    this.debouncedTransmit();
   }
 
   addLabel(signedLabel) {
     if (this.labels.has(signedLabel)) return;
     this.labels.add(signedLabel);
     this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(signedLabel));
-    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT) {
-      this.debouncedTransmit();
-    }
+    this.debouncedTransmit();
   }
 
   transmit(keepalive = false) {

--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -182,7 +182,10 @@ class Events {
     this.windowId = windowId;
 
     this.events = [];
-    this.eventBytes = 0;
+    this.tags = new Set();
+    this.labels = new Set();
+
+    this.payloadBytes = 0;
     this.flushIntervalId = null;
   }
 
@@ -202,31 +205,53 @@ class Events {
   }
 
   add(event) {
-    const serializedEvent = JSON.stringify(event);
-    const newEventBytes = lengthInUtf8Bytes(serializedEvent);
-
     this.events.push(event);
-    this.eventBytes = this.eventBytes + newEventBytes;
+    this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(event));
+    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT) {
+      this.debouncedTransmit();
+    }
+  }
 
-    if (this.eventBytes > KEEPALIVE_BYTE_LIMIT) {
-      this.events.push(event);
+  addTag(signedTag) {
+    if (this.tags.has(signedTag)) return;
+    this.tags.add(signedTag);
+    this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(signedTag));
+    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT) {
+      this.debouncedTransmit();
+    }
+  }
+
+  addLabel(signedLabel) {
+    if (this.labels.has(signedLabel)) return;
+    this.labels.add(signedLabel);
+    this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(signedLabel));
+    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT) {
       this.debouncedTransmit();
     }
   }
 
   transmit(keepalive = false) {
-    if (this.events.length === 0) {
-      return
+    if (this.events.length === 0 && this.tags.size === 0 && this.labels.size === 0) {
+      return;
     }
 
-    const body = JSON.stringify({
-      sessionId: this.sessionId,
-      windowId: this.windowId,
-      events: this.events
-    });
+    const events = [...this.events];
+    const tags = [...this.tags];
+    const labels = [...this.labels];
+    this.events = [];
+    this.tags = new Set();
+    this.labels = new Set();
+    this.payloadBytes = 0;
 
-    this.events.length = 0;
-    this.eventBytes = 0;
+    const payload = { sessionId: this.sessionId, windowId: this.windowId, events };
+    if (tags.length > 0) payload.tags = tags;
+    if (labels.length > 0) payload.labels = labels;
+
+    const body = JSON.stringify(payload);
+
+    if (keepalive && lengthInUtf8Bytes(body) > KEEPALIVE_BYTE_LIMIT) {
+      keepalive = false;
+    }
 
     fetch(POST_URL, {
       method: 'POST',
@@ -251,18 +276,14 @@ class Events {
 }
 
 class TagWatcher {
-  constructor(sessionId, windowId) {
-    this.sessionId = sessionId;
-    this.windowId = windowId;
-    this.seenTags = new Set();
-    this.pendingTags = [];
-    this.debounceTimeout = null;
+  constructor(events) {
+    this.events = events;
     this.observer = null;
   }
 
   start() {
     document.querySelectorAll(RECORDING_TAG_SELECTOR).forEach(el => {
-      this.enqueue(el.content);
+      this.events.addTag(el.content);
     });
 
     this.observer = new MutationObserver((mutations) => {
@@ -270,59 +291,27 @@ class TagWatcher {
         for (const node of mutation.addedNodes) {
           if (node.nodeType !== Node.ELEMENT_NODE) continue;
           if (node.matches(RECORDING_TAG_SELECTOR)) {
-            this.enqueue(node.content);
+            this.events.addTag(node.content);
           }
           node.querySelectorAll(RECORDING_TAG_SELECTOR).forEach(el => {
-            this.enqueue(el.content);
+            this.events.addTag(el.content);
           });
         }
       }
     });
     this.observer.observe(document.documentElement, { childList: true, subtree: true });
   }
-
-  enqueue(signedTag) {
-    if (this.seenTags.has(signedTag)) return;
-    this.seenTags.add(signedTag);
-    this.pendingTags.push(signedTag);
-    this.debouncedFlush();
-  }
-
-  debouncedFlush() {
-    if (!this.debounceTimeout) {
-      this.debounceTimeout = setTimeout(() => {
-        this.debounceTimeout = null;
-        this.flush();
-      }, 100);
-    }
-  }
-
-  flush() {
-    if (this.pendingTags.length === 0) return;
-    const tags = this.pendingTags.splice(0);
-    fetch(POST_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sessionId: this.sessionId, windowId: this.windowId, events: [], tags }),
-    }).catch((error) => {
-      console.error(error);
-    });
-  }
 }
 
 class LabelWatcher {
-  constructor(sessionId, windowId) {
-    this.sessionId = sessionId;
-    this.windowId = windowId;
-    this.seenLabels = new Set();
-    this.pendingLabels = [];
-    this.debounceTimeout = null;
+  constructor(events) {
+    this.events = events;
     this.observer = null;
   }
 
   start() {
     document.querySelectorAll(RECORDING_LABEL_SELECTOR).forEach(el => {
-      this.enqueue(el.content);
+      this.events.addLabel(el.content);
     });
 
     this.observer = new MutationObserver((mutations) => {
@@ -330,43 +319,15 @@ class LabelWatcher {
         for (const node of mutation.addedNodes) {
           if (node.nodeType !== Node.ELEMENT_NODE) continue;
           if (node.matches(RECORDING_LABEL_SELECTOR)) {
-            this.enqueue(node.content);
+            this.events.addLabel(node.content);
           }
           node.querySelectorAll(RECORDING_LABEL_SELECTOR).forEach(el => {
-            this.enqueue(el.content);
+            this.events.addLabel(el.content);
           });
         }
       }
     });
     this.observer.observe(document.documentElement, { childList: true, subtree: true });
-  }
-
-  enqueue(signedLabel) {
-    if (this.seenLabels.has(signedLabel)) return;
-    this.seenLabels.add(signedLabel);
-    this.pendingLabels.push(signedLabel);
-    this.debouncedFlush();
-  }
-
-  debouncedFlush() {
-    if (!this.debounceTimeout) {
-      this.debounceTimeout = setTimeout(() => {
-        this.debounceTimeout = null;
-        this.flush();
-      }, 100);
-    }
-  }
-
-  flush() {
-    if (this.pendingLabels.length === 0) return;
-    const labels = this.pendingLabels.splice(0);
-    fetch(POST_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sessionId: this.sessionId, windowId: this.windowId, events: [], labels }),
-    }).catch((error) => {
-      console.error(error);
-    });
   }
 }
 
@@ -457,10 +418,10 @@ if (!isStopped()) {
   recorder.start();
 }
 
-const tagWatcher = new TagWatcher(sessionId, windowId);
+const tagWatcher = new TagWatcher(recorder.events);
 tagWatcher.start();
 
-const labelWatcher = new LabelWatcher(sessionId, windowId);
+const labelWatcher = new LabelWatcher(recorder.events);
 labelWatcher.start();
 
 const stopWatcher = new StopWatcher(recorder);

--- a/spec/app/controllers/events_controller_spec.rb
+++ b/spec/app/controllers/events_controller_spec.rb
@@ -25,5 +25,26 @@ describe SpectatorSport::EventsController, type: :controller do
         session: SpectatorSport::Session.find_by(secure_id: payload[:sessionId])
       )
     end
+
+    it 'stores tags and labels bundled with events in a single request' do
+      tag_verifier = Rails.application.message_verifier(:spectator_sport_tag_recording)
+      label_verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
+
+      payload = {
+        "sessionId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "windowId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "events": [
+          { "type": 4, "data": { "href": "http://127.0.0.1:3000/", "width": 1512, "height": 770 }, "timestamp": 1727655888530 }
+        ],
+        "tags": [ tag_verifier.generate("beta-user") ],
+        "labels": [ label_verifier.generate({ "value" => "42", "key" => "user_id", "strategy" => "one" }) ]
+      }
+
+      post :create, params: payload
+
+      window = SpectatorSport::SessionWindow.find_by(secure_id: payload[:windowId])
+      expect(window.session_window_tags.pluck(:tag)).to include("beta-user")
+      expect(window.labels.where(key: "user_id", value: "42")).to exist
+    end
   end
 end

--- a/spec/system/recording_tags_spec.rb
+++ b/spec/system/recording_tags_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe "Recording tags", type: :system, js: true do
     expect(page).to have_text("Recordings tagged: user-27")
     expect(page).to have_css("table")
   end
+
+  it "transmits tags on page navigation without waiting for the flush interval" do
+    visit "/examples"
+    expect(page).to have_text("Your browser activity is being recorded.")
+    # Navigate away immediately (no wait_for_recording) to exercise the keepalive path
+    visit "/spectator_sport_dashboard"
+    expect(page).to have_text("user-27", wait: 3)
+  end
 end


### PR DESCRIPTION
Tags and labels are now accumulated in the `Events` class alongside rrweb events and transmitted together in a single fetch request, reducing the number of separate network requests. `TagWatcher` and `LabelWatcher` are simplified to delegate directly to new `Events#addTag` and `Events#addLabel` methods; both always trigger a debounced transmit (100ms) so tags and labels are still sent promptly regardless of event volume. A pre-existing bug where `Events#add` double-pushed events when over the byte limit is also fixed. Tests added: a controller spec verifying the server handles tags and labels bundled in a single payload, and a system spec verifying tags are transmitted on fast page navigation via the keepalive path.