### PR TITLE
Show all tags and labels in recordings table when viewing by tag

### DIFF
--- a/app/controllers/spectator_sport/dashboard/tags_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/tags_controller.rb
@@ -3,12 +3,15 @@ module SpectatorSport
     class TagsController < ApplicationController
       def show
         @tag = params[:name]
-        @session_windows = SpectatorSport::SessionWindowTag
-          .where(tag: @tag)
-          .includes(:session_window)
-          .order(created_at: :desc)
+        scope = SessionWindow
+          .joins(:session_window_tags)
+          .where(spectator_sport_session_window_tags: { tag: @tag })
+          .distinct
+          .order(updated_at: :desc)
           .limit(50)
-          .map(&:session_window)
+        scope = scope.includes(:session_window_tags) if SpectatorSport::SessionWindowTag.migrated?
+        scope = scope.includes(:labels) if SpectatorSport::Label.migrated?
+        @session_windows = scope
       end
     end
   end

--- a/app/views/spectator_sport/dashboard/shared/_session_windows.html.erb
+++ b/app/views/spectator_sport/dashboard/shared/_session_windows.html.erb
@@ -32,7 +32,6 @@
           <td>
             <% session_window.labels.each do |swl| %>
               <% if swl.key.present? %>
-                <%= link_to swl.key, label_key_path(swl.key) %>
                 <%= link_to swl.display, label_path(swl.key, swl.value) %>
               <% else %>
                 <%= link_to swl.value, label_tag_path(swl.value) %>

--- a/app/views/spectator_sport/dashboard/tags/show.html.erb
+++ b/app/views/spectator_sport/dashboard/tags/show.html.erb
@@ -1,29 +1,7 @@
 <div class="container my-3">
   <h2>Recordings tagged: <%= @tag %></h2>
   <% if @session_windows.any? %>
-    <div class="card mt-3">
-      <table class="table">
-        <caption class="visually-hidden">Recordings tagged <%= @tag %></caption>
-        <thead>
-        <tr>
-          <th>Recording</th>
-          <th>Session ID</th>
-          <th>Updated</th>
-          <th>Created</th>
-        </tr>
-        </thead>
-        <tbody>
-        <% @session_windows.each do |session_window| %>
-          <tr>
-            <td><%= link_to "Session (Window ##{session_window.id})", session_window_path(session_window.id) %></td>
-            <td><%= session_window.session_id %></td>
-            <td><%= tag.time(time_ago_in_words(session_window.updated_at), datetime: session_window.updated_at, title: session_window.updated_at) %>
-            <td><%= tag.time(time_ago_in_words(session_window.created_at), datetime: session_window.created_at, title: session_window.created_at) %>
-          </tr>
-        <% end %>
-        </tbody>
-      </table>
-    </div>
+    <%= render "spectator_sport/dashboard/shared/session_windows", session_windows: @session_windows %>
   <% else %>
     <em>No recordings found with tag "<%= @tag %>".</em>
   <% end %>

--- a/spec/system/recording_labels_spec.rb
+++ b/spec/system/recording_labels_spec.rb
@@ -16,17 +16,14 @@ RSpec.describe "Recording labels", type: :system, js: true do
     expect(page).to have_css("table")
   end
 
-  it "key link from dashboard navigates to key view showing all recordings with that key" do
+  it "displays keyed labels as a single combined 'key: value' link in the dashboard" do
     visit "/examples"
     expect(page).to have_text("Your browser activity is being recorded.")
     wait_for_recording
 
     visit "/spectator_sport_dashboard"
-    expect(page).to have_text("user_id")
-
-    first(:link, "user_id").click
-    expect(page).to have_text("Recordings with label key: user_id")
-    expect(page).to have_css("table")
+    expect(page).to have_link("user_id: 27")
+    expect(page).not_to have_link("user_id", exact: true)
   end
 
   it "key/value view links back to key view" do

--- a/spec/system/recording_labels_spec.rb
+++ b/spec/system/recording_labels_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe "Recording labels", type: :system, js: true do
     visit "/spectator_sport_dashboard"
     expect(page).to have_link("user_id: 27")
     expect(page).not_to have_link("user_id", exact: true)
+
+    first(:link, "user_id: 27").click
+    expect(page).to have_text("Recordings labeled: user_id: 27")
+    expect(page).to have_css("table")
   end
 
   it "key/value view links back to key view" do


### PR DESCRIPTION
## Summary
- The tags show page had its own inline table missing Tags and Labels columns; replaced it with the shared `_session_windows` partial used by all label views.
- Rewrote `TagsController#show` to query from `SessionWindow` with proper eager loading of tags and labels, fixing potential N+1 queries.
- Removed the redundant standalone key link in the Labels cell so key/value labels display only as a single "key: value" link.