### PR TITLE
Fix labels controller to load all labels on matching session windows

### DIFF
--- a/app/controllers/spectator_sport/dashboard/labels_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/labels_controller.rb
@@ -3,34 +3,32 @@ module SpectatorSport
     class LabelsController < ApplicationController
       def tags
         @value = params[:value]
-        @session_windows = session_windows_scope
-          .where(spectator_sport_labels: { key: nil, value: @value })
+        @session_windows = session_windows_scope(key: nil, value: @value)
       end
 
       def key_index
         @key = params[:key]
-        @session_windows = session_windows_scope
-          .where(spectator_sport_labels: { key: @key })
+        @session_windows = session_windows_scope(key: @key)
       end
 
       def show
         @key = params[:key]
         @value = params[:value]
-        @session_windows = session_windows_scope
-          .where(spectator_sport_labels: { key: @key, value: @value })
+        @session_windows = session_windows_scope(key: @key, value: @value)
       end
 
       private
 
-      def session_windows_scope
-        scope = SessionWindow
-          .joins(:labels)
+      def session_windows_scope(key:, value: SpectatorSport::NONE)
+        label_conditions = { key: key }
+        label_conditions[:value] = value unless value == SpectatorSport::NONE
+
+        SessionWindow
+          .where(id: SessionWindow.joins(:labels).where(spectator_sport_labels: label_conditions).select(:id))
+          .includes(:session_window_tags, :labels)
           .distinct
           .order(updated_at: :desc)
           .limit(50)
-        scope = scope.includes(:session_window_tags) if SpectatorSport::SessionWindowTag.migrated?
-        scope = scope.includes(:labels) if SpectatorSport::Label.migrated?
-        scope
       end
     end
   end

--- a/lib/spectator_sport.rb
+++ b/lib/spectator_sport.rb
@@ -2,5 +2,5 @@ require "spectator_sport/version"
 require "spectator_sport/engine"
 
 module SpectatorSport
-  # Your code goes here...
+  NONE = Object.new.freeze
 end

--- a/spec/app/controllers/dashboard/labels_controller_spec.rb
+++ b/spec/app/controllers/dashboard/labels_controller_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SpectatorSport::Dashboard::LabelsController, type: :controller do
+  render_views
+
+  before do
+    @routes = SpectatorSport::Dashboard::Engine.routes
+  end
+
+  let(:spectator_session) { SpectatorSport::Session.create!(secure_id: "test-session-id") }
+  let(:session_window) { SpectatorSport::SessionWindow.create!(session: spectator_session, secure_id: "test-window-id") }
+
+  describe "GET #tags" do
+    it "renders session windows with the matching tag label" do
+      SpectatorSport::Label.create!(session_window: session_window, key: nil, value: "featured", multiple: false)
+
+      get :tags, params: { value: "featured" }
+
+      expect(response).to be_successful
+      expect(response.body).to include("featured")
+    end
+
+    it "loads all labels on matching session windows, not just the filtered one" do
+      SpectatorSport::Label.create!(session_window: session_window, key: nil, value: "featured", multiple: false)
+      SpectatorSport::Label.create!(session_window: session_window, key: "env", value: "prod", multiple: false)
+
+      get :tags, params: { value: "featured" }
+
+      expect(response.body).to include("env")
+      expect(response.body).to include("prod")
+    end
+
+    it "does not include session windows without the label" do
+      other_session = SpectatorSport::Session.create!(secure_id: "other-session-id")
+      other_window = SpectatorSport::SessionWindow.create!(session: other_session, secure_id: "other-window-id")
+      SpectatorSport::Label.create!(session_window: other_window, key: nil, value: "other", multiple: false)
+
+      get :tags, params: { value: "featured" }
+
+      expect(response.body).not_to include("other-session-id")
+    end
+  end
+
+  describe "GET #key_index" do
+    it "renders session windows with the matching label key" do
+      SpectatorSport::Label.create!(session_window: session_window, key: "env", value: "prod", multiple: false)
+
+      get :key_index, params: { key: "env" }
+
+      expect(response).to be_successful
+      expect(response.body).to include("env")
+    end
+
+    it "loads all labels on matching session windows, not just the filtered one" do
+      SpectatorSport::Label.create!(session_window: session_window, key: "env", value: "prod", multiple: false)
+      SpectatorSport::Label.create!(session_window: session_window, key: "user_id", value: "42", multiple: false)
+
+      get :key_index, params: { key: "env" }
+
+      expect(response.body).to include("user_id")
+      expect(response.body).to include("42")
+    end
+  end
+
+  describe "GET #show" do
+    it "renders session windows with the matching label key and value" do
+      SpectatorSport::Label.create!(session_window: session_window, key: "env", value: "prod", multiple: false)
+
+      get :show, params: { key: "env", value: "prod" }
+
+      expect(response).to be_successful
+      expect(response.body).to include("env")
+      expect(response.body).to include("prod")
+    end
+
+    it "loads all labels on matching session windows, not just the filtered one" do
+      SpectatorSport::Label.create!(session_window: session_window, key: "env", value: "prod", multiple: false)
+      SpectatorSport::Label.create!(session_window: session_window, key: "user_id", value: "42", multiple: false)
+
+      get :show, params: { key: "env", value: "prod" }
+
+      expect(response.body).to include("user_id")
+      expect(response.body).to include("42")
+    end
+
+    it "does not include session windows with a different label value" do
+      other_session = SpectatorSport::Session.create!(secure_id: "other-session-id")
+      other_window = SpectatorSport::SessionWindow.create!(session: other_session, secure_id: "other-window-id")
+      SpectatorSport::Label.create!(session_window: other_window, key: "env", value: "staging", multiple: false)
+
+      get :show, params: { key: "env", value: "prod" }
+
+      expect(response.body).not_to include("other-session-id")
+    end
+  end
+end


### PR DESCRIPTION
- Fixes `LabelsController` so that when filtering session windows by a label, all labels on those session windows are eager-loaded (not just the one matched by the filter). Previously, `joins(:labels)` combined with `where` on `spectator_sport_labels` caused `includes(:labels)` to only load the matched label.
- The fix uses a subquery for filtering so `includes(:session_window_tags, :labels)` runs unconditionally without interference from the where clause.
- Adds `SpectatorSport::NONE` as a sentinel constant for optional keyword arguments (used to distinguish "not provided" from `nil`, which is a valid label key).
- Adds a controller spec for all three `LabelsController` actions, including an explicit test that all labels are loaded on matching session windows.