### PR TITLE
Deprecate tags in favor of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,6 @@ To install Spectator Sport in your Rails application:
         ```
   3. To view recordings, you will want to mount the Player Dashboard in your application and set up authorization to limit access. See the section on [Dashboard authorization](#dashboard-authorization) for instructions.
 
-## Tagging recordings
-
-You can associate a string tag (e.g. a user ID or account identifier) with the current recording by calling `spectator_sport_tag_recording` in any template:
-
-```erb
-<%= spectator_sport_tag_recording(current_user.id.to_s) %>
-```
-
-This renders a hidden `<meta>` element signed by the server. The recording client detects it and immediately sends it to the API, where the signature is verified before the tag is stored. Tags are displayed in the dashboard and can be used to look up all recordings associated with a given value.
-
-**Note:** this requires the `spectator_sport_session_window_tags` migration to be applied (`bin/rails spectator_sport:install:migrations && bin/rails db:migrate`). If the migration hasn't been run, the feature is silently disabled.
-
 ## Labeling recordings
 
 You can associate key-value labels with the current recording by calling `spectator_sport_label_recording` in any template:

--- a/app/controllers/spectator_sport/dashboard/session_windows_controller.rb
+++ b/app/controllers/spectator_sport/dashboard/session_windows_controller.rb
@@ -4,7 +4,6 @@ module SpectatorSport
       def show
         @session_window = SessionWindow.find(params[:id])
         @events = @session_window.events.page_after(nil)
-        @tags = SpectatorSport::SessionWindowTag.migrated? ? @session_window.session_window_tags.to_a : []
         @labels = SpectatorSport::Label.migrated? ? @session_window.labels.to_a : []
       end
 

--- a/app/helpers/spectator_sport/script_helper.rb
+++ b/app/helpers/spectator_sport/script_helper.rb
@@ -5,7 +5,7 @@ module SpectatorSport
     end
 
     def spectator_sport_tag_recording(tag_value)
-      ActiveSupport::Deprecation.new.warn(
+      SpectatorSport.deprecator.warn(
         "`spectator_sport_tag_recording` is deprecated and will be removed in a future version. " \
         "Use `spectator_sport_label_recording` instead."
       )

--- a/app/helpers/spectator_sport/script_helper.rb
+++ b/app/helpers/spectator_sport/script_helper.rb
@@ -5,8 +5,11 @@ module SpectatorSport
     end
 
     def spectator_sport_tag_recording(tag_value)
-      signed = Rails.application.message_verifier(:spectator_sport_tag_recording).generate(tag_value)
-      tag.meta(name: "spectator-sport-recording-tag", content: signed)
+      ActiveSupport::Deprecation.new.warn(
+        "`spectator_sport_tag_recording` is deprecated and will be removed in a future version. " \
+        "Use `spectator_sport_label_recording` instead."
+      )
+      spectator_sport_label_recording(tag_value)
     end
 
     def spectator_sport_label_recording(value, key: nil, strategy: :many)

--- a/app/views/spectator_sport/dashboard/session_windows/show.html.erb
+++ b/app/views/spectator_sport/dashboard/session_windows/show.html.erb
@@ -27,9 +27,8 @@
     </div>
   </div>
   <% keyed_labels = @labels.select { |l| l.key.present? }.group_by(&:key) %>
-  <% tag_values = @tags.map(&:tag) %>
   <% keyless_labels = @labels.select { |l| l.key.nil? }.map(&:value) %>
-  <% if keyed_labels.any? || tag_values.any? || keyless_labels.any? %>
+  <% if keyed_labels.any? || keyless_labels.any? %>
     <div class="card mt-3">
       <div class="card-header">Labels</div>
       <table class="table table-sm mb-0">
@@ -50,13 +49,10 @@
               </td>
             </tr>
           <% end %>
-          <% if tag_values.any? || keyless_labels.any? %>
+          <% if keyless_labels.any? %>
             <tr>
-              <td>Tags</td>
+              <td></td>
               <td>
-                <% tag_values.each do |tv| %>
-                  <%= link_to tv, tag_path(tv) %>
-                <% end %>
                 <% keyless_labels.each do |lv| %>
                   <%= link_to lv, label_tag_path(lv) %>
                 <% end %>

--- a/app/views/spectator_sport/dashboard/shared/_session_windows.html.erb
+++ b/app/views/spectator_sport/dashboard/shared/_session_windows.html.erb
@@ -5,9 +5,6 @@
     <tr>
       <th>Recording</th>
       <th>Session ID</th>
-      <% if SpectatorSport::SessionWindowTag.migrated? %>
-        <th>Tags</th>
-      <% end %>
       <% if SpectatorSport::Label.migrated? %>
         <th>Labels</th>
       <% end %>
@@ -21,13 +18,6 @@
       <tr>
         <td><%= link_to "Session (Window ##{session_window.id})", session_window_path(session_window.id) %></td>
         <td><%= session_window.session_id %></td>
-        <% if SpectatorSport::SessionWindowTag.migrated? %>
-          <td>
-            <% session_window.session_window_tags.each do |swt| %>
-              <%= link_to swt.tag, tag_path(swt.tag) %>
-            <% end %>
-          </td>
-        <% end %>
         <% if SpectatorSport::Label.migrated? %>
           <td>
             <% session_window.labels.each do |swl| %>

--- a/lib/spectator_sport.rb
+++ b/lib/spectator_sport.rb
@@ -3,4 +3,8 @@ require "spectator_sport/engine"
 
 module SpectatorSport
   NONE = Object.new.freeze
+
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("1.0", "spectator_sport")
+  end
 end

--- a/lib/spectator_sport/engine.rb
+++ b/lib/spectator_sport/engine.rb
@@ -2,6 +2,10 @@ module SpectatorSport
   class Engine < ::Rails::Engine
     isolate_namespace SpectatorSport
 
+    initializer "spectator_sport.deprecator" do |app|
+      app.deprecators[:spectator_sport] = SpectatorSport.deprecator
+    end
+
     initializer "local_helper.action_controller" do
       ActiveSupport.on_load :action_controller do
         # TODO: this should probably be done manually by the client, maybe?

--- a/spec/app/controllers/dashboard/session_windows_controller_spec.rb
+++ b/spec/app/controllers/dashboard/session_windows_controller_spec.rb
@@ -27,7 +27,6 @@ describe SpectatorSport::Dashboard::SessionWindowsController, type: :controller 
       expect(response.body).to include("user_id")
       expect(response.body).to include("42")
     end
-
   end
 
   describe "DELETE #destroy" do

--- a/spec/app/controllers/dashboard/session_windows_controller_spec.rb
+++ b/spec/app/controllers/dashboard/session_windows_controller_spec.rb
@@ -28,13 +28,6 @@ describe SpectatorSport::Dashboard::SessionWindowsController, type: :controller 
       expect(response.body).to include("42")
     end
 
-    it "renders tags when migrated" do
-      SpectatorSport::SessionWindowTag.create!(session_window: session_window, tag: "test-tag")
-
-      get :show, params: { id: session_window.id }
-
-      expect(response.body).to include("test-tag")
-    end
   end
 
   describe "DELETE #destroy" do

--- a/spec/system/recording_tags_spec.rb
+++ b/spec/system/recording_tags_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Recording tags", type: :system, js: true do
     expect(page).to have_text("user-27")
 
     first(:link, "user-27").click
-    expect(page).to have_text("Recordings tagged: user-27")
+    expect(page).to have_text("Recordings labeled: user-27")
     expect(page).to have_css("table")
   end
 


### PR DESCRIPTION
Tags are superseded by labels, which support key-value pairs and flexible strategies. This deprecates the tags feature in favor of labels.

- Remove "Tagging recordings" section from README
- Remove Tags column from the recordings table and tag display from the session window detail view
- `spectator_sport_tag_recording` now emits a deprecation warning and delegates to `spectator_sport_label_recording` (keyless label)