### PR TITLE
Keep rrweb player scrubber usable by disabling skip-inactive

### DIFF
--- a/app/frontend/spectator_sport/dashboard/modules/player_controller.js
+++ b/app/frontend/spectator_sport/dashboard/modules/player_controller.js
@@ -37,8 +37,6 @@ export default class extends Controller {
       this.linkUrlTarget.dataset.url = url;
     });
 
-    this.#keepScrubberEnabled();
-
     const playerElement = this.playerTarget.getElementsByClassName("rr-player")[0];
     playerElement.style.width = "100%";
     playerElement.style.height = null;
@@ -58,17 +56,7 @@ export default class extends Controller {
     element.remove();
   }
 
-  // rrweb disables the scrubber during fast-forward (skip inactive); strip it so users can still seek
-  #keepScrubberEnabled() {
-    const progress = this.playerTarget.querySelector('.rr-progress');
-    if (progress) {
-      this.scrubberObserver = new MutationObserver(() => progress.classList.remove('disabled'));
-      this.scrubberObserver.observe(progress, { attributeFilter: ['class'] });
-    }
-  }
-
   disconnect() {
-    this.scrubberObserver?.disconnect();
     this.player?.$destroy();
   }
 }

--- a/app/frontend/spectator_sport/dashboard/modules/player_controller.js
+++ b/app/frontend/spectator_sport/dashboard/modules/player_controller.js
@@ -37,6 +37,8 @@ export default class extends Controller {
       this.linkUrlTarget.dataset.url = url;
     });
 
+    this.#keepScrubberEnabled();
+
     const playerElement = this.playerTarget.getElementsByClassName("rr-player")[0];
     playerElement.style.width = "100%";
     playerElement.style.height = null;
@@ -56,7 +58,17 @@ export default class extends Controller {
     element.remove();
   }
 
+  // rrweb disables the scrubber during fast-forward (skip inactive); strip it so users can still seek
+  #keepScrubberEnabled() {
+    const progress = this.playerTarget.querySelector('.rr-progress');
+    if (progress) {
+      this.scrubberObserver = new MutationObserver(() => progress.classList.remove('disabled'));
+      this.scrubberObserver.observe(progress, { attributeFilter: ['class'] });
+    }
+  }
+
   disconnect() {
+    this.scrubberObserver?.disconnect();
     this.player?.$destroy();
   }
 }

--- a/app/frontend/spectator_sport/dashboard/modules/player_controller.js
+++ b/app/frontend/spectator_sport/dashboard/modules/player_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
         events: this.eventsValue,
         liveMode: true,
         skipInactive: false,
+        speedOption: [1, 2, 4, 8, 16],
       }
     });
 

--- a/app/frontend/spectator_sport/dashboard/modules/player_controller.js
+++ b/app/frontend/spectator_sport/dashboard/modules/player_controller.js
@@ -17,6 +17,7 @@ export default class extends Controller {
       props: {
         events: this.eventsValue,
         liveMode: true,
+        skipInactive: false,
       }
     });
 

--- a/app/frontend/spectator_sport/dashboard/style.css
+++ b/app/frontend/spectator_sport/dashboard/style.css
@@ -65,12 +65,6 @@
   width: 1rem;
 }
 
-/* rrweb sets cursor: not-allowed on the scrubber while fast-forwarding (skipping
-   inactivity); keep the normal pointer so it doesn't look broken */
-.rr-progress.disabled {
-  cursor: pointer !important;
-}
-
 /*Style table within card*/
 .card > table:first-child > thead > tr:first-child > th:first-child {
   border-top-left-radius: var(--bs-card-inner-border-radius);

--- a/app/frontend/spectator_sport/dashboard/style.css
+++ b/app/frontend/spectator_sport/dashboard/style.css
@@ -65,6 +65,12 @@
   width: 1rem;
 }
 
+/* rrweb sets cursor: not-allowed on the scrubber while fast-forwarding (skipping
+   inactivity); keep the normal pointer so it doesn't look broken */
+.rr-progress.disabled {
+  cursor: pointer !important;
+}
+
 /*Style table within card*/
 .card > table:first-child > thead > tr:first-child > th:first-child {
   border-top-left-radius: var(--bs-card-inner-border-radius);


### PR DESCRIPTION
rrweb-player defaults `skipInactive` to true, which drops the player into a 'skipping' state during idle periods — disabling the scrubber, showing a `not-allowed` cursor, and blocking seeking. This turns skip-inactive off so the scrubber stays fully usable.

- Pass `skipInactive: false` when constructing the player so it never enters the skipping state

Tradeoff: playback no longer fast-forwards through long idle gaps; those now play in real time.