### PR TITLE
Defer ScriptHelper registration to avoid boot-time NameError

### DIFF
--- a/lib/spectator_sport/engine.rb
+++ b/lib/spectator_sport/engine.rb
@@ -6,10 +6,10 @@ module SpectatorSport
       app.deprecators[:spectator_sport] = SpectatorSport.deprecator
     end
 
-    initializer "local_helper.action_controller" do
-      ActiveSupport.on_load :action_controller do
+    config.after_initialize do
+      ActiveSupport.on_load :action_view do
         # TODO: this should probably be done manually by the client, maybe?
-        helper SpectatorSport::ScriptHelper
+        include SpectatorSport::ScriptHelper
       end
     end
   end


### PR DESCRIPTION
The helper was wired up inside `ActiveSupport.on_load :action_controller` during an engine initializer. If a host app forces ActionController to load during the initializer phase (e.g. the `audited` gem references `ActionController::API` in its railtie), the hook fires before the engine's `app/helpers` dir is registered with Zeitwerk, so `SpectatorSport::ScriptHelper` is not yet autoloadable and boot dies with:

    uninitialized constant SpectatorSport::ScriptHelper

`on_load :action_controller` also fires for `ActionController::API`, which has no `.helper` method, so the eager registration was doubly fragile.

Move registration into `config.after_initialize` and include the module into ActionView via `on_load :action_view`. By after_initialize the autoload paths are set, and targeting ActionView sidesteps the Base/API distinction entirely.
