### PR TITLE
Encode labels/history/lifecycle as rrweb Custom events

### DIFF
--- a/app/controllers/spectator_sport/events_controller.rb
+++ b/app/controllers/spectator_sport/events_controller.rb
@@ -7,10 +7,10 @@ module SpectatorSport
 
     def create
       data = if params.key?(:events) && (params.key?(:recordingId) || params.key?(:windowId))
-        params.slice(:sessionId, :recordingId, :windowId, :events, :tags, :labels).stringify_keys
+        params.slice(:sessionId, :recordingId, :windowId, :events, :tags).stringify_keys
       else
         # beacon sends JSON in the request body
-        JSON.parse(request.body.read).slice("sessionId", "recordingId", "windowId", "events", "tags", "labels")
+        JSON.parse(request.body.read).slice("sessionId", "recordingId", "windowId", "events", "tags")
       end
 
       # `windowId` is the legacy name for `recordingId`; accept either for backward compatibility.
@@ -30,27 +30,66 @@ module SpectatorSport
 
     private
 
+    # The `spectator_sport:label` Custom event carries the signed label payload verbatim
+    # (it's emitted client-side from the same signed meta tag content that used to be sent
+    # separately in a `labels` array); decrypt it here so only the decoded key/value/strategy
+    # ever reach the database, and so Label.record can be driven from this event below.
+    def decode_label_event(event)
+      signed = event.dig("data", "payload", "signed")
+      label_data = begin
+        signed.is_a?(String) ? Rails.application.message_verifier(:spectator_sport_label_recording).verified(signed) : nil
+      rescue StandardError
+        nil
+      end
+      decoded_payload = label_data.is_a?(Hash) ? { "key" => label_data["key"], "value" => label_data["value"], "strategy" => label_data["strategy"] } : {}
+
+      # Rebuilt as a plain Hash (not `event.merge(...)`) so the result is a predictable Hash
+      # regardless of whether `event` arrived as an ActionController::Parameters (form-encoded
+      # requests) or a plain Hash (JSON body requests).
+      {
+        "type" => event["type"],
+        "timestamp" => event["timestamp"],
+        "data" => { "tag" => event.dig("data", "tag"), "payload" => decoded_payload }
+      }
+    end
+
     def create_recording(data, events)
       recording = Recording.find_or_create_by(secure_id: data["recordingId"])
 
-      records_data = events.map do |event|
-        { recording_id: recording.id, event_data: event, created_at: Time.at(event["timestamp"].to_f / 1000.0) }
-      end.to_a
+      # custom_tag isn't a persisted column (yet), so it's only kept around here to find the
+      # label events below, not written to the database.
+      decoded_events = events.map do |event|
+        event_type = Event::EVENT_TYPES[event["type"].to_s]
+        custom_tag = event_type == "Custom" ? event.dig("data", "tag") : nil
+        event = decode_label_event(event) if custom_tag == CustomEvents::LABEL
+        { event: event, event_type: event_type, custom_tag: custom_tag }
+      end
+
+      records_data = decoded_events.map do |decoded|
+        event = decoded[:event]
+        event_type = decoded[:event_type]
+        {
+          recording_id: recording.id,
+          event_data: event,
+          event_type: event_type,
+          event_source: event_type == "IncrementalSnapshot" ? Event::EVENT_SOURCES[event.dig("data", "source").to_s] : nil,
+          created_at: Time.at(event["timestamp"].to_f / 1000.0)
+        }
+      end
       Event.insert_all(records_data) if records_data.any?
 
       last_event = records_data.max_by { |record| record[:created_at] }
       recording.update(updated_at: last_event[:created_at]) if last_event
 
       if SpectatorSport::Label.migrated?
-        verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
-        Array(data["labels"]).first(20).each do |signed_label|
-          label_data = verifier.verified(signed_label)
-          next unless label_data.is_a?(Hash)
+        decoded_events.select { |decoded| decoded[:custom_tag] == CustomEvents::LABEL }.first(20).each do |decoded|
+          payload = decoded[:event].dig("data", "payload")
+          next unless payload.is_a?(Hash) && payload["value"]
           Label.record(
             recording: recording,
-            value: label_data["value"],
-            key: label_data["key"],
-            strategy: label_data["strategy"]
+            value: payload["value"],
+            key: payload["key"],
+            strategy: payload["strategy"]
           )
         rescue StandardError
           nil
@@ -77,22 +116,6 @@ module SpectatorSport
           next unless tag_value.is_a?(String) && tag_value.present?
           SessionWindowTag.find_or_create_by(session_window: window, tag: tag_value)
         rescue ActiveRecord::RecordNotUnique
-          nil
-        end
-      end
-
-      if SpectatorSport::Label.migrated?
-        verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
-        Array(data["labels"]).first(20).each do |signed_label|
-          label_data = verifier.verified(signed_label)
-          next unless label_data.is_a?(Hash)
-          Label.record(
-            session_window: window,
-            value: label_data["value"],
-            key: label_data["key"],
-            strategy: label_data["strategy"]
-          )
-        rescue StandardError
           nil
         end
       end

--- a/app/models/spectator_sport/custom_events.rb
+++ b/app/models/spectator_sport/custom_events.rb
@@ -1,0 +1,7 @@
+module SpectatorSport
+  module CustomEvents
+    LABEL = "spectator_sport:label"
+    HISTORY = "spectator_sport:history"
+    LIFECYCLE = "spectator_sport:lifecycle"
+  end
+end

--- a/app/models/spectator_sport/event.rb
+++ b/app/models/spectator_sport/event.rb
@@ -11,13 +11,52 @@ module SpectatorSport
     Explanation = Struct.new(:title, :details)
 
     # taken from https://github.com/rrweb-io/rrweb/blob/9488deb6d54a5f04350c063d942da5e96ab74075/src/types.ts
-    EVENT_TYPES = %w[DomContentLoaded Load FullSnapshot IncrementalSnapshot Meta Custom]
+    # Keyed by string digits (not indexed by integer) since the raw ordinal may arrive, or be
+    # read back out of the event_data json column, as either an Integer or a String.
+    EVENT_TYPES = {
+      "0" => "DomContentLoaded",
+      "1" => "Load",
+      "2" => "FullSnapshot",
+      "3" => "IncrementalSnapshot",
+      "4" => "Meta",
+      "5" => "Custom",
+      "6" => "Plugin",
+      "7" => "Asset"
+    }
 
-    EVENT_SOURCES = %w[Mutation MouseMove MouseInteraction Scroll ViewportResize Input TouchMove MediaInteraction
-                       StyleSheetRule CanvasMutation Font Log Drag StyleDeclaration Selection AdoptedStyleSheet]
+    EVENT_SOURCES = {
+      "0" => "Mutation",
+      "1" => "MouseMove",
+      "2" => "MouseInteraction",
+      "3" => "Scroll",
+      "4" => "ViewportResize",
+      "5" => "Input",
+      "6" => "TouchMove",
+      "7" => "MediaInteraction",
+      "8" => "StyleSheetRule",
+      "9" => "CanvasMutation",
+      "10" => "Font",
+      "11" => "Log",
+      "12" => "Drag",
+      "13" => "StyleDeclaration",
+      "14" => "Selection",
+      "15" => "AdoptedStyleSheet",
+      "16" => "CustomElement"
+    }
 
-    MOUSE_INTERACTIONS = %w[MouseUp MouseDown Click ContextMenu DblClick Focus Blur TouchStart TouchMove_Departed
-                            TouchEnd TouchCancel]
+    MOUSE_INTERACTIONS = {
+      "0" => "MouseUp",
+      "1" => "MouseDown",
+      "2" => "Click",
+      "3" => "ContextMenu",
+      "4" => "DblClick",
+      "5" => "Focus",
+      "6" => "Blur",
+      "7" => "TouchStart",
+      "8" => "TouchMove_Departed",
+      "9" => "TouchEnd",
+      "10" => "TouchCancel"
+    }
 
     def explanation
       explanation = Explanation.new(title, [])
@@ -31,26 +70,16 @@ module SpectatorSport
       end
 
       if event_source == "MouseInteraction"
-        mouse_interaction = MOUSE_INTERACTIONS[event_data.dig("data", "type")]
+        mouse_interaction = MOUSE_INTERACTIONS[event_data.dig("data", "type").to_s]
         explanation.details << "#{mouse_interaction}"
       end
 
       explanation
     end
 
-    def event_type
-      EVENT_TYPES[event_data["type"]]
-    end
-
-    def event_source
-      return unless event_data.dig("data", "source")
-
-      EVENT_SOURCES[event_data.dig("data", "source")]
-    end
-
     def title
       if event_type == "IncrementalSnapshot" && event_source == "MouseInteraction" &&
-          MOUSE_INTERACTIONS[event_data.dig("data", "type")] == "Click"
+          MOUSE_INTERACTIONS[event_data.dig("data", "type").to_s] == "Click"
         "Mouse Click"
       else
         event_type
@@ -60,5 +89,15 @@ module SpectatorSport
     def page
       event_data.dig("data", "href")
     end
+
+    def label? = event_data.dig("data", "tag") == CustomEvents::LABEL
+    def label_key = event_data.dig("data", "payload", "key")
+    def label_value = event_data.dig("data", "payload", "value")
+
+    def history? = event_data.dig("data", "tag") == CustomEvents::HISTORY
+    def history_href = event_data.dig("data", "payload", "href")
+
+    def lifecycle? = event_data.dig("data", "tag") == CustomEvents::LIFECYCLE
+    def lifecycle_reason = event_data.dig("data", "payload", "reason")
   end
 end

--- a/app/views/spectator_sport/events/index.js
+++ b/app/views/spectator_sport/events/index.js
@@ -140,6 +140,12 @@ const RECORDING_TAG_SELECTOR = 'meta[name="spectator-sport-recording-tag"]';
 const RECORDING_LABEL_SELECTOR = 'meta[name="spectator-sport-recording-label"]';
 const STOP_SELECTOR = 'meta[name="spectator-sport-stop"]';
 
+const CustomEvents = {
+  LABEL: "spectator_sport:label",
+  HISTORY: "spectator_sport:history",
+  LIFECYCLE: "spectator_sport:lifecycle",
+};
+
 // sessionId is retained for backward compatibility with older servers that
 // store events under a Session/SessionWindow pair. New servers key on recordingId.
 function getSessionId() {
@@ -205,6 +211,10 @@ class Recorder {
   unpause() {
     this.start();
   }
+
+  customEvent(tag, payload) {
+    if (this.stopRrwebCallback) rrwebRecord.addCustomEvent(tag, payload);
+  }
 }
 
 class Events {
@@ -214,7 +224,6 @@ class Events {
 
     this.events = [];
     this.tags = new Set();
-    this.labels = new Set();
 
     this.payloadBytes = 0;
     this.flushIntervalId = null;
@@ -238,7 +247,9 @@ class Events {
   add(event) {
     this.events.push(event);
     this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(event));
-    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT) {
+    // Custom label events skip the periodic 15s flush so labels reach the server promptly,
+    // the way the old dedicated labels channel used to.
+    if (this.payloadBytes > KEEPALIVE_BYTE_LIMIT || event.data?.tag === CustomEvents.LABEL) {
       this.debouncedTransmit();
     }
   }
@@ -250,30 +261,20 @@ class Events {
     this.debouncedTransmit();
   }
 
-  addLabel(signedLabel) {
-    if (this.labels.has(signedLabel)) return;
-    this.labels.add(signedLabel);
-    this.payloadBytes += lengthInUtf8Bytes(JSON.stringify(signedLabel));
-    this.debouncedTransmit();
-  }
-
   transmit(keepalive = false) {
-    if (this.events.length === 0 && this.tags.size === 0 && this.labels.size === 0) {
+    if (this.events.length === 0 && this.tags.size === 0) {
       return;
     }
 
     const events = [...this.events];
     const tags = [...this.tags];
-    const labels = [...this.labels];
     this.events = [];
     this.tags = new Set();
-    this.labels = new Set();
     this.payloadBytes = 0;
 
     // sessionId is sent for backward compatibility with older servers; new servers key on recordingId.
     const payload = { sessionId: this.sessionId, recordingId: this.recordingId, events };
     if (tags.length > 0) payload.tags = tags;
-    if (labels.length > 0) payload.labels = labels;
 
     const body = JSON.stringify(payload);
 
@@ -332,14 +333,20 @@ class TagWatcher {
 }
 
 class LabelWatcher {
-  constructor(events) {
-    this.events = events;
+  constructor(recorder) {
+    this.recorder = recorder;
     this.observer = null;
+  }
+
+  // el.content is the signed payload from spectator_sport_label_recording; the server
+  // decrypts it into event_data on ingestion, so no plaintext label data is ever recorded here.
+  #addLabel(el) {
+    this.recorder.customEvent(CustomEvents.LABEL, { signed: el.content });
   }
 
   start() {
     document.querySelectorAll(RECORDING_LABEL_SELECTOR).forEach(el => {
-      this.events.addLabel(el.content);
+      this.#addLabel(el);
     });
 
     this.observer = new MutationObserver((mutations) => {
@@ -347,10 +354,10 @@ class LabelWatcher {
         for (const node of mutation.addedNodes) {
           if (node.nodeType !== Node.ELEMENT_NODE) continue;
           if (node.matches(RECORDING_LABEL_SELECTOR)) {
-            this.events.addLabel(node.content);
+            this.#addLabel(node);
           }
           node.querySelectorAll(RECORDING_LABEL_SELECTOR).forEach(el => {
-            this.events.addLabel(el.content);
+            this.#addLabel(el);
           });
         }
       }
@@ -393,6 +400,29 @@ class StopWatcher {
   }
 }
 
+class HistoryWatcher {
+  constructor(recorder) {
+    this.recorder = recorder;
+  }
+
+  start() {
+    const emitHistoryEvent = () => {
+      this.recorder.customEvent(CustomEvents.HISTORY, { href: location.href });
+    };
+
+    for (const method of [ "pushState", "replaceState" ]) {
+      const original = history[method];
+      history[method] = function (...args) {
+        const result = original.apply(this, args);
+        emitHistoryEvent();
+        return result;
+      };
+    }
+
+    window.addEventListener("popstate", emitHistoryEvent);
+  }
+}
+
 function isStopped() {
   return !!document.querySelector(STOP_SELECTOR);
 }
@@ -415,6 +445,7 @@ class PageLifecycleManager {
       this.recorder.stop();
     } else {
       this.recorder.start();
+      this.recorder.customEvent(CustomEvents.LIFECYCLE, { reason: "bfcache-restore" });
     }
   }
 
@@ -449,11 +480,14 @@ if (!isStopped()) {
 const tagWatcher = new TagWatcher(recorder.events);
 tagWatcher.start();
 
-const labelWatcher = new LabelWatcher(recorder.events);
+const labelWatcher = new LabelWatcher(recorder);
 labelWatcher.start();
 
 const stopWatcher = new StopWatcher(recorder);
 stopWatcher.start();
+
+const historyWatcher = new HistoryWatcher(recorder);
+historyWatcher.start();
 
 const lifecycleManager = new PageLifecycleManager(recorder);
 lifecycleManager.start();

--- a/db/migrate/20260707000000_add_event_type_columns_to_spectator_sport_events.rb
+++ b/db/migrate/20260707000000_add_event_type_columns_to_spectator_sport_events.rb
@@ -1,0 +1,6 @@
+class AddEventTypeColumnsToSpectatorSportEvents < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spectator_sport_events, :event_type, :string
+    add_column :spectator_sport_events, :event_source, :string
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,10 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_19_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_000000) do
   create_table "spectator_sport_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.json "event_data", null: false
+    t.string "event_source"
+    t.string "event_type"
     t.integer "recording_id"
     t.integer "session_id"
     t.integer "session_window_id"
@@ -34,8 +36,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_19_000000) do
     t.datetime "updated_at", null: false
     t.string "value", null: false
     t.index [ "key", "value" ], name: "index_spectator_sport_labels_on_key_and_value"
-    t.index [ "recording_id" ], name: "index_spectator_sport_labels_on_recording_id"
     t.index [ "recording_id", "key" ], name: "index_labels_unique_singular_key_per_recording", unique: true, where: "multiple = false AND key IS NOT NULL"
+    t.index [ "recording_id" ], name: "index_spectator_sport_labels_on_recording_id"
     t.index [ "session_window_id", "key", "value" ], name: "idx_on_session_window_id_key_value_98301751dd"
     t.index [ "session_window_id", "key" ], name: "index_labels_unique_singular_key_per_window", unique: true, where: "multiple = false AND key IS NOT NULL"
     t.index [ "session_window_id" ], name: "index_spectator_sport_labels_on_session_window_id"

--- a/spec/app/controllers/events_controller_spec.rb
+++ b/spec/app/controllers/events_controller_spec.rb
@@ -42,16 +42,107 @@ describe SpectatorSport::EventsController, type: :controller do
       )
     end
 
-    it 'stores labels bundled with events in a single request' do
+    it 'decodes event_type and event_source for a Meta event' do
+      payload = {
+        "sessionId": "fb1x1aji7p5nljgnydya9kid7vncrzw48ir7d70h",
+        "recordingId": "873h0zhhw66i9f1t36rh5myu8pzwopt676v9s83z",
+        "events": [
+          { "type": 4, "data": { "href": "http://127.0.0.1:3000/", "width": 1512, "height": 770 }, "timestamp": 1727655888530 }
+        ]
+      }
+
+      post :create, params: payload
+
+      expect(SpectatorSport::Event.last).to have_attributes(
+        event_type: "Meta",
+        event_source: nil
+      )
+    end
+
+    it 'decodes event_type and event_source for an IncrementalSnapshot/MouseInteraction event' do
+      payload = {
+        "sessionId": "fb1x1aji7p5nljgnydya9kid7vncrzw48ir7d70h",
+        "recordingId": "873h0zhhw66i9f1t36rh5myu8pzwopt676v9s83z",
+        "events": [
+          { "type": 3, "data": { "source": 2, "type": 2, "id": 5 }, "timestamp": 1727655888530 }
+        ]
+      }
+
+      post :create, params: payload
+
+      expect(SpectatorSport::Event.last).to have_attributes(
+        event_type: "IncrementalSnapshot",
+        event_source: "MouseInteraction"
+      )
+    end
+
+    it 'decrypts the signed payload of a Custom/label event and stores only the decoded key/value' do
       label_verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
+      signed = label_verifier.generate({ "value" => "27", "key" => "user_id", "strategy" => "many" })
+
+      payload = {
+        "sessionId": "fb1x1aji7p5nljgnydya9kid7vncrzw48ir7d70h",
+        "recordingId": "873h0zhhw66i9f1t36rh5myu8pzwopt676v9s83z",
+        "events": [
+          { "type": 5, "data": { "tag": "spectator_sport:label", "payload": { "signed": signed } }, "timestamp": 1727655888530 }
+        ]
+      }
+
+      post :create, params: payload
+
+      event = SpectatorSport::Event.last
+      expect(event).to have_attributes(event_type: "Custom", event_source: nil)
+      expect(event.label?).to eq(true)
+      expect(event.label_key).to eq("user_id")
+      expect(event.label_value).to eq("27")
+      expect(event.event_data.dig("data", "payload")).not_to have_key("signed")
+    end
+
+    it 'stores an empty payload for a Custom/label event with an invalid signature' do
+      payload = {
+        "sessionId": "fb1x1aji7p5nljgnydya9kid7vncrzw48ir7d70h",
+        "recordingId": "873h0zhhw66i9f1t36rh5myu8pzwopt676v9s83z",
+        "events": [
+          { "type": 5, "data": { "tag": "spectator_sport:label", "payload": { "signed": "not-a-valid-signature" } }, "timestamp": 1727655888530 }
+        ]
+      }
+
+      post :create, params: payload
+
+      event = SpectatorSport::Event.last
+      expect(event.label?).to eq(true)
+      expect(event.label_key).to be_nil
+      expect(event.label_value).to be_nil
+    end
+
+    it 'decodes event_type for a Custom/history event' do
+      payload = {
+        "sessionId": "fb1x1aji7p5nljgnydya9kid7vncrzw48ir7d70h",
+        "recordingId": "873h0zhhw66i9f1t36rh5myu8pzwopt676v9s83z",
+        "events": [
+          { "type": 5, "data": { "tag": "spectator_sport:history", "payload": { "href": "http://127.0.0.1:3000/next" } }, "timestamp": 1727655888530 }
+        ]
+      }
+
+      post :create, params: payload
+
+      event = SpectatorSport::Event.last
+      expect(event).to have_attributes(event_type: "Custom", event_source: nil)
+      expect(event.history?).to eq(true)
+      expect(event.history_href).to eq("http://127.0.0.1:3000/next")
+    end
+
+    it 'records a Label from a Custom/label event bundled with events in a single request' do
+      label_verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
+      signed = label_verifier.generate({ "value" => "42", "key" => "user_id", "strategy" => "one" })
 
       payload = {
         "sessionId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "recordingId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "events": [
-          { "type": 4, "data": { "href": "http://127.0.0.1:3000/", "width": 1512, "height": 770 }, "timestamp": 1727655888530 }
-        ],
-        "labels": [ label_verifier.generate({ "value" => "42", "key" => "user_id", "strategy" => "one" }) ]
+          { "type": 4, "data": { "href": "http://127.0.0.1:3000/", "width": 1512, "height": 770 }, "timestamp": 1727655888530 },
+          { "type": 5, "data": { "tag": "spectator_sport:label", "payload": { "signed": signed } }, "timestamp": 1727655888531 }
+        ]
       }
 
       post :create, params: payload
@@ -97,24 +188,6 @@ describe SpectatorSport::EventsController, type: :controller do
           session: SpectatorSport::Session.find_by(secure_id: payload[:sessionId]),
           session_window: SpectatorSport::SessionWindow.find_by(secure_id: payload[:windowId])
         )
-      end
-
-      it 'stores labels on the session_window' do
-        label_verifier = Rails.application.message_verifier(:spectator_sport_label_recording)
-
-        payload = {
-          "sessionId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          "recordingId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          "events": [
-            { "type": 4, "data": { "href": "http://127.0.0.1:3000/", "width": 1512, "height": 770 }, "timestamp": 1727655888530 }
-          ],
-          "labels": [ label_verifier.generate({ "value" => "42", "key" => "user_id", "strategy" => "one" }) ]
-        }
-
-        post :create, params: payload
-
-        window = SpectatorSport::SessionWindow.find_by(secure_id: payload[:recordingId])
-        expect(window.labels.where(key: "user_id", value: "42")).to exist
       end
 
       it 'stores tags on the session_window' do

--- a/spec/app/models/spectator_sport/event_spec.rb
+++ b/spec/app/models/spectator_sport/event_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SpectatorSport::Event do
+  # The test database isn't reset between examples, so every recording is
+  # namespaced to this spec to avoid colliding with events created elsewhere.
+  def create_event(secure_id, event_type:, event_data:, event_source: nil)
+    recording = SpectatorSport::Recording.create!(secure_id: "event-spec-#{secure_id}")
+    described_class.create!(
+      recording: recording,
+      event_data: event_data,
+      event_type: event_type,
+      event_source: event_source
+    )
+  end
+
+  describe "#label?, #label_key, #label_value" do
+    it "decodes the key/value payload of a label Custom event" do
+      event = create_event(
+        "label",
+        event_type: "Custom",
+        event_data: { "type" => 5, "data" => { "tag" => "spectator_sport:label", "payload" => { "key" => "user_id", "value" => "27" } } }
+      )
+
+      expect(event.label?).to eq(true)
+      expect(event.label_key).to eq("user_id")
+      expect(event.label_value).to eq("27")
+      expect(event.history?).to eq(false)
+      expect(event.lifecycle?).to eq(false)
+    end
+  end
+
+  describe "#history?, #history_href" do
+    it "decodes the href payload of a history Custom event" do
+      event = create_event(
+        "history",
+        event_type: "Custom",
+        event_data: { "type" => 5, "data" => { "tag" => "spectator_sport:history", "payload" => { "href" => "http://127.0.0.1:3000/next" } } }
+      )
+
+      expect(event.history?).to eq(true)
+      expect(event.history_href).to eq("http://127.0.0.1:3000/next")
+      expect(event.label?).to eq(false)
+    end
+  end
+
+  describe "#lifecycle?, #lifecycle_reason" do
+    it "decodes the reason payload of a lifecycle Custom event" do
+      event = create_event(
+        "lifecycle",
+        event_type: "Custom",
+        event_data: { "type" => 5, "data" => { "tag" => "spectator_sport:lifecycle", "payload" => { "reason" => "bfcache-restore" } } }
+      )
+
+      expect(event.lifecycle?).to eq(true)
+      expect(event.lifecycle_reason).to eq("bfcache-restore")
+    end
+  end
+
+  describe "#title and #explanation" do
+    it "uses the persisted event_type/event_source columns" do
+      event = create_event(
+        "mouse-click",
+        event_type: "IncrementalSnapshot",
+        event_source: "MouseInteraction",
+        event_data: { "type" => 3, "data" => { "source" => 2, "type" => 2 } }
+      )
+
+      expect(event.title).to eq("Mouse Click")
+      expect(event.explanation.title).to eq("Mouse Click")
+      expect(event.explanation.details).to include("source: MouseInteraction", "Click")
+    end
+
+    it "reports the href from event_data for a Meta event" do
+      event = create_event(
+        "meta",
+        event_type: "Meta",
+        event_data: { "type" => 4, "data" => { "href" => "http://127.0.0.1:3000/" } }
+      )
+
+      expect(event.explanation.details).to include("visited http://127.0.0.1:3000/")
+    end
+  end
+end


### PR DESCRIPTION
Replaces the dedicated `labels` ingest channel with rrweb Custom events so labels, SPA navigation, and bfcache lifecycle transitions all flow through the same event pipeline, and persists event type/source as columns instead of recomputing them on every read.

The goal is to make it easier to query/analyze raw events so that we may (eventually) build first-class features into Spectator Sport (like rage click detection, for example)
